### PR TITLE
feat(browsers): add Carbonyl terminal browser

### DIFF
--- a/scripts/setup-dev-tools-linux.sh
+++ b/scripts/setup-dev-tools-linux.sh
@@ -234,7 +234,7 @@ list_categories() {
     printf "  %-25s %s\n" "linux-system"        "p7zip, gnome-sushi, caffeine, Mullvad VPN"
     printf "  %-25s %s\n" "linux-productivity"  "Flameshot, Espanso, Notion, Filezilla"
     printf "  %-25s %s\n" "linux-communication" "Slack, Telegram, Signal"
-    printf "  %-25s %s\n" "linux-browsers"      "Firefox, Brave, Chrome"
+    printf "  %-25s %s\n" "linux-browsers"      "Firefox, Brave, Chrome, Carbonyl"
     printf "  %-25s %s\n" "linux-media"         "mpv, oxipng, jpegoptim, LibreOffice"
     printf "  %-25s %s\n" "linux-cloud"         "rclone, syncthing, borgbackup, borgmatic"
     printf "  %-25s %s\n" "linux-focus"         "NewsFlash (RSS)"
@@ -2858,6 +2858,8 @@ if ! installed google-chrome-stable; then
     setup_chrome_repo
     pkg_install "google-chrome-stable" "google-chrome-stable" "-" "Google Chrome"
 fi
+
+npm_global_install "carbonyl" "Carbonyl (Chromium-based browser for the terminal)"
 
 fi  # linux-browsers
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -246,7 +246,7 @@ list_categories() {
     printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins"
     printf "  %-25s %s\n" "mac-productivity"    "Notion, Skim, Transmit"
     printf "  %-25s %s\n" "mac-communication"   "Slack, Telegram"
-    printf "  %-25s %s\n" "mac-browsers"        "Firefox, Brave"
+    printf "  %-25s %s\n" "mac-browsers"        "Firefox, Brave, Carbonyl"
     printf "  %-25s %s\n" "mac-media"           "mpv, oxipng, jpegoptim, 7zip, LibreOffice"
     printf "  %-25s %s\n" "mac-cloud"           "Google Drive, rclone, borg"
     printf "  %-25s %s\n" "mac-focus"           "newsboat"
@@ -1501,6 +1501,8 @@ banner "Mac Apps — Browsers"
 brew_cask_install "google-chrome" "Google Chrome"
 brew_cask_install "firefox" "Firefox"
 brew_cask_install "brave-browser" "Brave Browser (privacy-focused Chromium)"
+
+npm_global_install "carbonyl" "Carbonyl (Chromium-based browser for the terminal)"
 
 fi  # mac-browsers
 

--- a/scripts/setup-dev-tools-windows.ps1
+++ b/scripts/setup-dev-tools-windows.ps1
@@ -244,7 +244,7 @@ function Show-Categories {
         @("win-system",            "BCUninstaller, 7zip, simplewall, QuickLook, PowerToys, Mullvad VPN")
         @("win-productivity",      "Notion, ShareX, Espanso, SumatraPDF")
         @("win-communication",     "Slack, Telegram, Signal")
-        @("win-browsers",          "Firefox, Arc, Brave")
+        @("win-browsers",          "Firefox, Arc, Brave, Carbonyl")
         @("win-media",             "mpv, oxipng, jpegoptim, LibreOffice")
         @("win-cloud",             "Google Drive, rclone, Syncthing")
         @("win-focus",             "Reeder alternative")
@@ -1276,6 +1276,8 @@ Write-Banner "Windows Apps -- Browsers"
 Install-WingetPackage "Mozilla.Firefox" "Firefox"
 Install-WingetPackage "TheBrowserCompany.Arc" "Arc (modern Chromium browser)"
 Install-WingetPackage "BraveSoftware.BraveBrowser" "Brave Browser (privacy-focused Chromium)"
+
+Install-NpmGlobal "carbonyl" "Carbonyl (Chromium-based browser for the terminal)"
 
 } # win-browsers
 


### PR DESCRIPTION
## Summary
- Add [Carbonyl](https://github.com/fathyb/carbonyl) (Chromium-based browser that runs in the terminal) to the browsers category across all three platform scripts
- Installed via npm (`npm install -g carbonyl`) since that's its primary distribution channel

## Changes
- `setup-dev-tools-mac.sh`: add `npm_global_install "carbonyl"` to `mac-browsers`, update category description
- `setup-dev-tools-linux.sh`: add `npm_global_install "carbonyl"` to `linux-browsers`, update category description
- `setup-dev-tools-windows.ps1`: add `Install-NpmGlobal "carbonyl"` to `win-browsers`, update category description

## Test plan
- [ ] Run `./scripts/setup-dev-tools-mac.sh --dry-run --only mac-browsers` and verify carbonyl appears
- [ ] Run `./scripts/setup-dev-tools-linux.sh --dry-run --only linux-browsers` and verify carbonyl appears
- [ ] Run `./scripts/setup-dev-tools-windows.ps1 -DryRun -Only win-browsers` and verify carbonyl appears
- [ ] Run `./scripts/setup-dev-tools-mac.sh --list` and verify Carbonyl shows in mac-browsers description

🤖 Generated with [Claude Code](https://claude.com/claude-code)