### PR TITLE
feat(tools): add w3m, monolith, cmus, nnn, progress, act3, sshclick

### DIFF
--- a/scripts/setup-dev-tools-linux.sh
+++ b/scripts/setup-dev-tools-linux.sh
@@ -218,15 +218,15 @@ list_categories() {
     printf "  %-25s %s\n" "security"            "detect-secrets, gitleaks, trivy, semgrep, Snyk, ClamAV"
     printf "  %-25s %s\n" "replacements"        "eza, bat, fd, ripgrep, zoxide, btop, sd, dust, just, yazi, fx, etc."
     printf "  %-25s %s\n" "data-processing"     "yq, miller, csvkit, pandoc, ffmpeg, ImageMagick"
-    printf "  %-25s %s\n" "code-quality"        "shellcheck, shfmt, act, hadolint, ruff, commitizen, ni"
+    printf "  %-25s %s\n" "code-quality"        "shellcheck, shfmt, act, act3, hadolint, ruff, commitizen, ni"
     printf "  %-25s %s\n" "perf-testing"        "hyperfine, oha"
     printf "  %-25s %s\n" "dev-servers"         "ngrok, miniserve, caddy"
-    printf "  %-25s %s\n" "terminal-productivity" "glow, watchexec, pv, parallel, gum, nushell, newsboat, topgrade, fastfetch, lnav"
+    printf "  %-25s %s\n" "terminal-productivity" "glow, watchexec, pv, parallel, gum, nushell, newsboat, topgrade, fastfetch, lnav, nnn, progress"
     printf "  %-25s %s\n" "k8s-github"          "stern, gh-dash"
     printf "  %-25s %s\n" "database"            "pgcli, mycli, lazysql, usql, sq"
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
     printf "  %-25s %s\n" "api"                 "Bruno, grpcurl"
-    printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap"
+    printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap, sshclick"
     printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, VS Code, Zed, Alacritty, tmux"
     printf "  %-25s %s\n" "ui"                  "Storybook, Playwright, Chrome"
     printf "  %-25s %s\n" "ux"                  "Lighthouse"
@@ -234,8 +234,8 @@ list_categories() {
     printf "  %-25s %s\n" "linux-system"        "p7zip, gnome-sushi, caffeine, Mullvad VPN"
     printf "  %-25s %s\n" "linux-productivity"  "Flameshot, Espanso, Notion, Filezilla"
     printf "  %-25s %s\n" "linux-communication" "Slack, Telegram, Signal"
-    printf "  %-25s %s\n" "linux-browsers"      "Firefox, Brave, Chrome, Carbonyl"
-    printf "  %-25s %s\n" "linux-media"         "mpv, oxipng, jpegoptim, LibreOffice"
+    printf "  %-25s %s\n" "linux-browsers"      "Firefox, Brave, Chrome, Carbonyl, w3m, monolith"
+    printf "  %-25s %s\n" "linux-media"         "mpv, oxipng, jpegoptim, LibreOffice, cmus"
     printf "  %-25s %s\n" "linux-cloud"         "rclone, syncthing, borgbackup, borgmatic"
     printf "  %-25s %s\n" "linux-focus"         "NewsFlash (RSS)"
     printf "  %-25s %s\n" "linux-disk"          "ncdu"
@@ -2171,6 +2171,19 @@ else
     progress
 fi
 
+# act3 (glance at last 3 GitHub Actions runs)
+if ! installed act3; then
+    if installed brew; then
+        brew tap dhth/tap >> "$LOG_FILE" 2>&1 || true
+        brew_install "act3" "act3 (glance at last 3 GitHub Actions runs)"
+    else
+        github_release_install "dhth/act3" "act3" "https://github.com/dhth/act3/releases/download/VERSION/act3_VERSION_linux_ARCH.tar.gz" "act3 (glance at last 3 GitHub Actions runs)"
+    fi
+else
+    warn "act3 already installed"
+    progress
+fi
+
 # hadolint (Dockerfile linter)
 if ! installed hadolint; then
     if installed brew; then
@@ -2376,6 +2389,12 @@ else
     progress
 fi
 
+# nnn (tiny, fast terminal file manager)
+pkg_install "nnn" "nnn" "nnn" "nnn (tiny, fast terminal file manager)"
+
+# progress (coreutils progress viewer)
+pkg_install "progress" "progress" "progress" "progress (coreutils progress viewer — cp, mv, dd, tar)"
+
 fi  # terminal-productivity
 
 # =============================================================================
@@ -2546,6 +2565,9 @@ pkg_install "mtr" "mtr" "mtr" "mtr (combines ping + traceroute)"
 cargo_install "bandwhich" "bandwhich (real-time bandwidth by process)"
 pkg_install "nmap" "nmap" "nmap" "nmap (network scanning)"
 cargo_install "trippy" "trippy (modern traceroute TUI with charts)"
+
+# sshclick (SSH config manager)
+pip_install "sshclick" "sshclick (SSH config manager — organize ~/.ssh/config)"
 
 fi  # networking
 
@@ -2861,6 +2883,24 @@ fi
 
 npm_global_install "carbonyl" "Carbonyl (Chromium-based browser for the terminal)"
 
+# w3m (text-based terminal browser)
+pkg_install "w3m" "w3m" "w3m" "w3m (text-based terminal browser and pager)"
+
+# monolith (save complete web pages as a single HTML file)
+if ! installed monolith; then
+    case "$PKG_MANAGER" in
+        apt) pkg_install "monolith" "-" "-" "monolith (save web pages as single HTML)" ;;
+        dnf) pkg_install "-" "monolith" "-" "monolith (save web pages as single HTML)" ;;
+        pacman) pkg_install "-" "-" "monolith" "monolith (save web pages as single HTML)" ;;
+    esac
+    if ! installed monolith; then
+        cargo_install "monolith" "monolith (save web pages as single HTML)"
+    fi
+else
+    warn "monolith already installed"
+    progress
+fi
+
 fi  # linux-browsers
 
 # =============================================================================
@@ -2876,6 +2916,9 @@ pkg_install "jpegoptim" "jpegoptim" "jpegoptim" "jpegoptim (lossless JPEG compre
 
 # LibreOffice (usually pre-installed)
 pkg_install "libreoffice" "libreoffice" "libreoffice-fresh" "LibreOffice"
+
+# cmus (ncurses terminal music player)
+pkg_install "cmus" "cmus" "cmus" "cmus (ncurses terminal music player)"
 
 fi  # linux-media
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -231,10 +231,10 @@ list_categories() {
     printf "  %-25s %s\n" "security"            "detect-secrets, gitleaks, trivy, semgrep, Snyk, ClamAV, Objective-See"
     printf "  %-25s %s\n" "replacements"        "eza, bat, fd, ripgrep, zoxide, btop, sd, dust, just, yazi, fx, etc."
     printf "  %-25s %s\n" "data-processing"     "yq, miller, csvkit, pandoc, ffmpeg, ImageMagick"
-    printf "  %-25s %s\n" "code-quality"        "shellcheck, shfmt, act, hadolint, ruff, commitizen, ni"
+    printf "  %-25s %s\n" "code-quality"        "shellcheck, shfmt, act, act3, hadolint, ruff, commitizen, ni"
     printf "  %-25s %s\n" "perf-testing"        "hyperfine, oha"
     printf "  %-25s %s\n" "dev-servers"         "ngrok, miniserve, caddy"
-    printf "  %-25s %s\n" "terminal-productivity" "glow, watchexec, pv, parallel, gum, nushell, topgrade, fastfetch"
+    printf "  %-25s %s\n" "terminal-productivity" "glow, watchexec, pv, parallel, gum, nushell, topgrade, fastfetch, nnn, progress"
     printf "  %-25s %s\n" "k8s-github"          "stern, gh-dash"
     printf "  %-25s %s\n" "database"            "pgcli, mycli, usql, sq, TablePlus"
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
@@ -246,8 +246,8 @@ list_categories() {
     printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins"
     printf "  %-25s %s\n" "mac-productivity"    "Notion, Skim, Transmit"
     printf "  %-25s %s\n" "mac-communication"   "Slack, Telegram"
-    printf "  %-25s %s\n" "mac-browsers"        "Firefox, Brave, Carbonyl"
-    printf "  %-25s %s\n" "mac-media"           "mpv, oxipng, jpegoptim, 7zip, LibreOffice"
+    printf "  %-25s %s\n" "mac-browsers"        "Firefox, Brave, Carbonyl, w3m, monolith"
+    printf "  %-25s %s\n" "mac-media"           "mpv, oxipng, jpegoptim, 7zip, LibreOffice, cmus"
     printf "  %-25s %s\n" "mac-cloud"           "Google Drive, rclone, borg"
     printf "  %-25s %s\n" "mac-focus"           "newsboat"
     printf "  %-25s %s\n" "mac-bloat"           "Remove pre-installed Apple apps (GarageBand)"
@@ -1213,6 +1213,8 @@ banner "Code Quality"
 brew_install "shellcheck" "shellcheck (shell script linter)"
 brew_install "shfmt" "shfmt (shell script formatter)"
 brew_install "act" "act (run GitHub Actions locally)"
+brew tap dhth/tap >> "$LOG_FILE" 2>&1 || true
+brew_install "act3" "act3 (glance at last 3 GitHub Actions runs)"
 brew_install "hadolint" "hadolint (Dockerfile linter — catches bad practices)"
 
 # Python linting (ruff — extremely fast, replaces flake8+black+isort)
@@ -1265,6 +1267,8 @@ brew_install "topgrade" "topgrade (update everything — brew, npm, pip, macOS, 
 brew_install "fastfetch" "fastfetch (quick system info display — faster neofetch)"
 brew_install "nano" "nano (latest — better than macOS built-in)"
 brew_install "lnav" "lnav (advanced log file viewer — auto-format, SQL queries on logs)"
+brew_install "nnn" "nnn (tiny, fast terminal file manager)"
+brew_install "progress" "progress (coreutils progress viewer — cp, mv, dd, tar)"
 
 fi  # terminal-productivity
 
@@ -1503,6 +1507,8 @@ brew_cask_install "firefox" "Firefox"
 brew_cask_install "brave-browser" "Brave Browser (privacy-focused Chromium)"
 
 npm_global_install "carbonyl" "Carbonyl (Chromium-based browser for the terminal)"
+brew_install "w3m" "w3m (text-based terminal browser and pager)"
+brew_install "monolith" "monolith (save complete web pages as a single HTML file)"
 
 fi  # mac-browsers
 
@@ -1514,6 +1520,7 @@ brew_install "mpv" "mpv (terminal video player)"
 brew_install "oxipng" "oxipng (lossless PNG compression)"
 brew_install "jpegoptim" "jpegoptim (lossless JPEG compression)"
 brew_install "p7zip" "7zip (archive tool — zip, 7z, rar, tar)"
+brew_install "cmus" "cmus (ncurses terminal music player)"
 brew_cask_install "libreoffice" "LibreOffice (free office suite)"
 
 fi  # mac-media

--- a/scripts/setup-dev-tools-windows.ps1
+++ b/scripts/setup-dev-tools-windows.ps1
@@ -228,7 +228,7 @@ function Show-Categories {
         @("security",              "detect-secrets, gitleaks, trivy, semgrep, simplewall, Wireshark")
         @("replacements",          "eza, bat, fd, ripgrep, zoxide, btop, sd, dust, just, yazi, fx, etc.")
         @("data-processing",       "yq, miller, csvkit, pandoc, ffmpeg, ImageMagick")
-        @("code-quality",          "shellcheck, shfmt, act, hadolint, ruff, npkill, commitizen")
+        @("code-quality",          "shellcheck, shfmt, act, act3, hadolint, ruff, npkill, commitizen")
         @("perf-testing",          "hyperfine, oha")
         @("dev-servers",           "ngrok, miniserve, caddy")
         @("terminal-productivity", "glow, watchexec, pv, parallel, topgrade, fastfetch, lnav")
@@ -244,8 +244,8 @@ function Show-Categories {
         @("win-system",            "BCUninstaller, 7zip, simplewall, QuickLook, PowerToys, Mullvad VPN")
         @("win-productivity",      "Notion, ShareX, Espanso, SumatraPDF")
         @("win-communication",     "Slack, Telegram, Signal")
-        @("win-browsers",          "Firefox, Arc, Brave, Carbonyl")
-        @("win-media",             "mpv, oxipng, jpegoptim, LibreOffice")
+        @("win-browsers",          "Firefox, Arc, Brave, Carbonyl, w3m, monolith")
+        @("win-media",             "mpv, oxipng, jpegoptim, LibreOffice, cmus")
         @("win-cloud",             "Google Drive, rclone, Syncthing")
         @("win-focus",             "Reeder alternative")
         @("win-disk",              "dust, duf")
@@ -989,6 +989,7 @@ Write-Banner "Code Quality"
 Install-ScoopPackage "shellcheck" "shellcheck (shell script linter)"
 Install-ScoopPackage "shfmt" "shfmt (shell script formatter)"
 Install-ScoopPackage "act" "act (run GitHub Actions locally)"
+Install-ScoopPackage "act3" "act3 (glance at last 3 GitHub Actions runs)"
 Install-ScoopPackage "hadolint" "hadolint (Dockerfile linter)"
 Install-ScoopPackage "ruff" "ruff (fast Python linter+formatter)"
 Install-ScoopPackage "typos" "typos (source code spell checker -- fast, low false positives)"
@@ -1278,6 +1279,8 @@ Install-WingetPackage "TheBrowserCompany.Arc" "Arc (modern Chromium browser)"
 Install-WingetPackage "BraveSoftware.BraveBrowser" "Brave Browser (privacy-focused Chromium)"
 
 Install-NpmGlobal "carbonyl" "Carbonyl (Chromium-based browser for the terminal)"
+Install-ScoopPackage "w3m" "w3m (text-based terminal browser and pager)"
+Install-ScoopPackage "monolith" "monolith (save complete web pages as a single HTML file)"
 
 } # win-browsers
 
@@ -1289,6 +1292,7 @@ Install-ScoopPackage "mpv" "mpv (modern video player -- replaces IINA)"
 Install-ScoopPackage "oxipng" "oxipng (lossless PNG compression)"
 Install-ScoopPackage "jpegoptim" "jpegoptim (lossless JPEG compression)"
 Install-WingetPackage "TheDocumentFoundation.LibreOffice" "LibreOffice (free office suite)"
+Install-ScoopPackage "cmus" "cmus (ncurses terminal music player)"
 
 } # win-media
 


### PR DESCRIPTION
## Summary
Add seven terminal CLI tools across the three platform install scripts, placed in the most appropriate existing categories. Closes #2.

## Changes
| Tool | macOS | Linux | Windows |
|------|-------|-------|---------|
| w3m | mac-browsers (brew) | linux-browsers (pkg) | win-browsers (scoop) |
| monolith | mac-browsers (brew) | linux-browsers (pkg/cargo) | win-browsers (scoop) |
| cmus | mac-media (brew) | linux-media (pkg) | win-media (scoop) |
| nnn | terminal-productivity (brew) | terminal-productivity (pkg) | skip |
| progress | terminal-productivity (brew) | terminal-productivity (pkg) | skip |
| act3 | code-quality (brew tap dhth/tap) | code-quality (brew tap or github_release fallback) | code-quality (scoop) |
| sshclick | skip | networking (pip_install) | skip |

### Skipped
- **slack-term** — archived upstream (no commits since 2019), no package in any manager
- **sshclick** on mac/Windows — scripts have no pip/pipx helper, Linux-only

### Implementation notes
- Reuses existing helpers (\`brew_install\`, \`pkg_install\`, \`cargo_install\`, \`pip_install\`, \`github_release_install\`, \`Install-ScoopPackage\`, \`Install-NpmGlobal\`) — no new helpers
- Follows existing patterns: \`act3\` mirrors the \`act\` block on Linux (brew-or-github_release fallback); mac uses the \`brew tap X/Y\` precedent from \`common-fate/granted\` and \`snyk/tap\`
- Category description strings in \`list_categories()\` / \`Show-Categories\` updated for all affected categories
- monolith on Linux falls back to \`cargo_install\` when the distro package is missing

## Test plan
- [ ] \`bash -n scripts/setup-dev-tools-mac.sh\` passes (verified locally)
- [ ] \`bash -n scripts/setup-dev-tools-linux.sh\` passes (verified locally)
- [ ] CI PSScriptAnalyzer passes on \`scripts/setup-dev-tools-windows.ps1\`
- [ ] \`./scripts/setup-dev-tools-mac.sh --list\` shows new tools in category descriptions
- [ ] Dry-run on each platform: \`--dry-run --only <categories>\` shows each new tool exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)