### PR TITLE
feat(docs,configs): document new terminal CLI tools + add configs/aliases

### DIFF
--- a/docs/GUIDE-LINUX.md
+++ b/docs/GUIDE-LINUX.md
@@ -77,6 +77,12 @@ zi                  # interactive selection with fzf
 # File manager (yazi)
 y                   # open terminal file manager
 # j/k to navigate, l to enter, h to go back, q to quit
+
+# Alternative file manager (nnn — minimal, fast, keyboard-driven)
+n                   # alias: nnn -de (detail view, open text in pager)
+# Inside nnn: arrows to navigate, Enter to open, ! to spawn shell,
+#             ^G cd-quit to parent shell, q to quit, ? for help
+# Env vars: NNN_OPTS, NNN_COLORS, NNN_PLUG are pre-configured
 ```
 
 ### Searching
@@ -132,6 +138,11 @@ df                  # duf: colorful disk free table
 # Process management
 ps                  # procs: sortable process list
 ps --tree           # process tree view
+
+# Monitor ongoing cp/mv/dd/tar (progress)
+prog                # alias: progress -m — live % for running coreutils
+progress -w         # one-shot snapshot for all copy/move/dd ops
+# Useful when you started a big `cp` in another pane and want live ETA.
 ```
 
 ---
@@ -592,6 +603,15 @@ act push                     # simulate push event
 act -j test                  # run specific job
 ```
 
+### act3 (glance at last 3 GitHub Actions runs)
+
+```bash
+gha3                         # alias: view last 3 runs of every workflow
+act3 -r owner/repo           # view runs for a specific repo
+act3 -t html > status.html   # export HTML status page
+# Requires a GitHub token: `gh auth login` or $GH_TOKEN
+```
+
 ---
 
 ## Networking & Debugging
@@ -644,6 +664,16 @@ xh -d api.example.com/file  # download file
 
 curlie httpbin.org/get       # curl syntax, httpie output
 curlie -X POST api.example.com -d '{"key":"val"}'
+```
+
+### sshclick (SSH config manager)
+
+```bash
+sshc host list                              # alias: list hosts in ~/.ssh/config
+sshclick host add prod --hostname prod.example.com --user deploy
+sshclick host show prod                     # show merged config for a host
+sshclick group list                         # view host groups
+# Organizes ~/.ssh/config with groups, comments, and safe edits.
 ```
 
 ---
@@ -701,6 +731,42 @@ yt-dlp --list-formats URL                # show available formats
 7z x archive.7z              # extract
 7z l archive.zip             # list contents
 7z a -tzip archive.zip files/ # create zip specifically
+```
+
+### cmus (terminal music player)
+
+```bash
+cmus                         # launch the TUI
+# Inside cmus:
+#   1–7 — switch views (library, playlist, queue, browser, filters, settings)
+#   a   — add directory to library
+#   c   — toggle pause     x — play     v — stop
+#   b / z — next / previous track
+#   s / r — toggle shuffle / repeat
+#   /   — search current view    q — quit
+# Config: ~/.config/cmus/rc (Dracula colors pre-configured)
+```
+
+### w3m (terminal web browser)
+
+```bash
+w3m https://example.com      # open URL in terminal
+w3m -dump https://example.com  # dump rendered text to stdout
+w3m -T text/html local.html  # render a local HTML file
+# Inside w3m:
+#   Tab — next link    Enter — follow link
+#   B   — back         U — enter URL     a — add bookmark
+#   q   — quit         h — help
+# Config: ~/.w3m/config (UTF-8, cookies off by default)
+```
+
+### monolith (save pages as single HTML)
+
+```bash
+monolith https://example.com -o page.html
+monolith https://example.com -o page.html --no-js --no-audio
+monolith -o bundle.html /tmp/local.html     # bundle a local file with deps
+# Embeds CSS, JS, images, and fonts inline — single-file web archive.
 ```
 
 ---

--- a/docs/GUIDE-MACOS.md
+++ b/docs/GUIDE-MACOS.md
@@ -59,6 +59,12 @@ zi                  # interactive selection with fzf
 # File manager (yazi)
 y                   # open terminal file manager
 # j/k to navigate, l to enter, h to go back, q to quit
+
+# Alternative file manager (nnn — minimal, fast, keyboard-driven)
+n                   # alias: nnn -de (detail view, open text in pager)
+# Inside nnn: arrows to navigate, Enter to open, ! to spawn shell,
+#             ^G cd-quit to parent shell, q to quit, ? for help
+# Env vars: NNN_OPTS, NNN_COLORS, NNN_PLUG are pre-configured
 ```
 
 ### Searching
@@ -106,6 +112,11 @@ df                  # duf: colorful disk free table
 # Process management
 ps                  # procs: sortable process list
 ps --tree           # process tree view
+
+# Monitor ongoing cp/mv/dd/tar (progress)
+prog                # alias: progress -m — live % for running coreutils
+progress -w         # one-shot snapshot for all copy/move/dd ops
+# Useful when you started a big `cp` in another pane and want live ETA.
 ```
 
 ---
@@ -521,6 +532,15 @@ act push                     # simulate push event
 act -j test                  # run specific job
 ```
 
+### act3 (glance at last 3 GitHub Actions runs)
+
+```bash
+gha3                         # alias: view last 3 runs of every workflow
+act3 -r owner/repo           # view runs for a specific repo
+act3 -t html > status.html   # export HTML status page
+# Requires a GitHub token: `gh auth login` or $GH_TOKEN
+```
+
 ---
 
 ## Networking & Debugging
@@ -638,6 +658,42 @@ yt-dlp --list-formats URL                # show available formats
 7z x archive.7z              # extract
 7z l archive.zip             # list contents
 7z a -tzip archive.zip files/ # create zip specifically
+```
+
+### cmus (terminal music player)
+
+```bash
+cmus                         # launch the TUI
+# Inside cmus:
+#   1–7 — switch views (library, playlist, queue, browser, filters, settings)
+#   a   — add directory to library
+#   c   — toggle pause     x — play     v — stop
+#   b / z — next / previous track
+#   s / r — toggle shuffle / repeat
+#   /   — search current view    q — quit
+# Config: ~/.config/cmus/rc (Dracula colors pre-configured)
+```
+
+### w3m (terminal web browser)
+
+```bash
+w3m https://example.com      # open URL in terminal
+w3m -dump https://example.com  # dump rendered text to stdout
+w3m -T text/html local.html  # render a local HTML file
+# Inside w3m:
+#   Tab — next link    Enter — follow link
+#   B   — back         U — enter URL     a — add bookmark
+#   q   — quit         h — help
+# Config: ~/.w3m/config (UTF-8, cookies off by default)
+```
+
+### monolith (save pages as single HTML)
+
+```bash
+monolith https://example.com -o page.html
+monolith https://example.com -o page.html --no-js --no-audio
+monolith -o bundle.html /tmp/local.html     # bundle a local file with deps
+# Embeds CSS, JS, images, and fonts inline — single-file web archive.
 ```
 
 ---

--- a/docs/GUIDE-WINDOWS.md
+++ b/docs/GUIDE-WINDOWS.md
@@ -629,6 +629,15 @@ act push                     # simulate push event
 act -j test                  # run specific job
 ```
 
+### act3 (glance at last 3 GitHub Actions runs)
+
+```powershell
+gha3                         # alias: view last 3 runs of every workflow
+act3 -r owner/repo           # view runs for a specific repo
+act3 -t html > status.html   # export HTML status page
+# Requires a GitHub token: `gh auth login` or $env:GH_TOKEN
+```
+
 ---
 
 ## Networking & Debugging
@@ -739,6 +748,34 @@ yt-dlp --list-formats URL                # show available formats
 7z x archive.7z              # extract
 7z l archive.zip             # list contents
 7z a -tzip archive.zip files\ # create zip specifically
+```
+
+### cmus (terminal music player)
+
+```powershell
+cmus                         # launch the TUI
+# Inside cmus:
+#   1–7 — switch views (library, playlist, queue, browser, filters, settings)
+#   a   — add directory to library    c — pause    x — play    v — stop
+#   b / z — next / previous track     s / r — shuffle / repeat
+#   / — search      q — quit
+# On Windows, audio routing depends on the Scoop build; may require WASAPI setup.
+```
+
+### w3m (terminal web browser)
+
+```powershell
+w3m https://example.com      # open URL in terminal
+w3m -dump https://example.com  # dump rendered text to stdout
+# Inside w3m: Tab — next link, Enter — follow, B — back, U — enter URL, q — quit
+```
+
+### monolith (save pages as single HTML)
+
+```powershell
+monolith https://example.com -o page.html
+monolith https://example.com -o page.html --no-js --no-audio
+# Embeds CSS, JS, images, and fonts inline — single-file web archive.
 ```
 
 ---

--- a/docs/SHORTCUTS-LINUX.md
+++ b/docs/SHORTCUTS-LINUX.md
@@ -56,6 +56,7 @@ Linux-specific alias differences from macOS:
 | `ghd` | `gh dash` | GitHub dashboard (PRs, issues) |
 | `gdft` | `git dft` | Syntax-aware git diff |
 | `gha` | `act` | Run GitHub Actions locally |
+| `gha3` | `act3` | Glance at last 3 GitHub Actions runs |
 
 ### Containers & Kubernetes
 
@@ -99,6 +100,14 @@ Linux-specific alias differences from macOS:
 | `par` | `parallel` | GNU parallel |
 | `lint-sh` | `shellcheck` | Lint shell scripts |
 | `fmt-sh` | `shfmt -w -i 4` | Format shell scripts |
+
+### Terminal Apps
+
+| Alias | Runs | What it does |
+|-------|------|-------------|
+| `n` | `nnn -de` | File manager (detail view, text in pager) |
+| `prog` | `progress -m` | Live progress bars for running cp/mv/dd/tar |
+| `sshc` | `sshclick` | SSH config manager for `~/.ssh/config` |
 
 ### Directory Shortcuts (via zoxide)
 

--- a/docs/SHORTCUTS-MACOS.md
+++ b/docs/SHORTCUTS-MACOS.md
@@ -45,6 +45,7 @@ Quick reference for all **209+ shortcuts** configured by the setup scripts.
 | `ghd` | `gh dash` | GitHub dashboard (PRs, issues) |
 | `gdft` | `git dft` | Syntax-aware git diff |
 | `gha` | `act` | Run GitHub Actions locally |
+| `gha3` | `act3` | Glance at last 3 GitHub Actions runs |
 
 ### Containers & Kubernetes
 
@@ -88,6 +89,13 @@ Quick reference for all **209+ shortcuts** configured by the setup scripts.
 | `par` | `parallel` | GNU parallel |
 | `lint-sh` | `shellcheck` | Lint shell scripts |
 | `fmt-sh` | `shfmt -w -i 4` | Format shell scripts |
+
+### Terminal Apps
+
+| Alias | Runs | What it does |
+|-------|------|-------------|
+| `n` | `nnn -de` | File manager (detail view, text in pager) |
+| `prog` | `progress -m` | Live progress bars for running cp/mv/dd/tar |
 
 ### Directory Shortcuts (via zoxide)
 

--- a/docs/SHORTCUTS-WINDOWS.md
+++ b/docs/SHORTCUTS-WINDOWS.md
@@ -47,6 +47,7 @@ Quick reference for all shortcuts and aliases configured by the setup scripts on
 | `ghd` | `gh dash` | GitHub dashboard (PRs, issues) |
 | `gdft` | `git dft` | Syntax-aware git diff |
 | `gha` | `act` | Run GitHub Actions locally |
+| `gha3` | `act3` | Glance at last 3 GitHub Actions runs |
 
 ### Containers & Kubernetes
 

--- a/scripts/setup-dev-tools-linux.sh
+++ b/scripts/setup-dev-tools-linux.sh
@@ -4262,6 +4262,95 @@ MLR_CONF
     success "miller configured"
 fi
 
+# ---- cmus config ----
+CMUS_CONFIG_DIR="$HOME/.config/cmus"
+CMUS_CONFIG="$CMUS_CONFIG_DIR/rc"
+if [[ -f "$CMUS_CONFIG" ]]; then
+    warn "cmus config already exists"
+else
+    info "Creating cmus config (Dracula-inspired colors)..."
+    mkdir -p "$CMUS_CONFIG_DIR"
+    cat > "$CMUS_CONFIG" <<'CMUS_CONF'
+# cmus configuration — Dracula-inspired colors
+# Apply inside cmus with:  :source ~/.config/cmus/rc
+
+set replaygain=track
+set replaygain_limit=true
+
+set format_current= %a — %t
+set format_playlist= %-20%a %t (%l)
+set format_trackwin= %-20%a %t (%l)
+
+# Dracula palette (256-color)
+set color_bg=-1
+set color_cmdline_bg=-1
+set color_cmdline_fg=253
+set color_info=141
+set color_error=203
+set color_separator=61
+set color_statusline_bg=61
+set color_statusline_fg=253
+set color_titleline_bg=61
+set color_titleline_fg=253
+set color_win_bg=-1
+set color_win_cur=141
+set color_win_cur_sel_bg=61
+set color_win_cur_sel_fg=253
+set color_win_dir=117
+set color_win_fg=253
+set color_win_inactive_cur_sel_bg=61
+set color_win_inactive_cur_sel_fg=253
+set color_win_inactive_sel_bg=-1
+set color_win_inactive_sel_fg=141
+set color_win_sel_bg=61
+set color_win_sel_fg=253
+set color_win_title_bg=61
+set color_win_title_fg=253
+CMUS_CONF
+    success "cmus configured (Dracula colors, replaygain)"
+fi
+
+# ---- w3m config ----
+W3M_CONFIG_DIR="$HOME/.w3m"
+W3M_CONFIG="$W3M_CONFIG_DIR/config"
+if [[ -f "$W3M_CONFIG" ]]; then
+    warn "w3m config already exists"
+else
+    info "Creating w3m config (UTF-8, cookies off, colors)..."
+    mkdir -p "$W3M_CONFIG_DIR"
+    cat > "$W3M_CONFIG" <<'W3M_CONF'
+# w3m configuration — sensible privacy + display defaults
+display_charset UTF-8
+document_charset UTF-8
+system_charset UTF-8
+auto_detect 2
+
+display_image 0
+use_mouse 1
+tabstop 8
+show_lnum 0
+
+color 1
+basic_color terminal
+anchor_color blue
+image_color green
+form_color red
+mark_color cyan
+
+# Privacy — disable cookies by default
+use_cookie 0
+accept_cookie 0
+show_cookie 0
+
+follow_redirection 5
+use_proxy 1
+
+bookmark bookmark.html
+keep_cache_in_memory 0
+W3M_CONF
+    success "w3m configured (UTF-8, cookies off)"
+fi
+
 # ---- asciinema config ----
 ASCIINEMA_CONFIG_DIR="$HOME/.config/asciinema"
 ASCIINEMA_CONFIG="$ASCIINEMA_CONFIG_DIR/config"
@@ -7686,6 +7775,12 @@ export FZF_CTRL_T_OPTS=\"--preview 'bat --color=always --style=numbers --line-ra
 export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'
 export FZF_ALT_C_OPTS=\"--preview 'eza --tree --icons --level=2 --color=always {}' --preview-window='right:50%:wrap'\"
 
+# -- nnn (terminal file manager) ----------------------------------------------
+export NNN_OPTS=\"deH\"
+export NNN_COLORS=\"2136\"
+export NNN_FCOLORS=\"c1e2272e006033f7c6d6abc4\"
+export NNN_PLUG=\"f:fzcd;o:fzopen;p:preview-tui\"
+
 # zsh plugins"
 
 if [[ -n "$ZSH_AUTOSUGGEST_PATH" ]]; then
@@ -7738,6 +7833,7 @@ alias lg=\"lazygit\"
 alias ghd=\"gh dash\"
 alias gdft=\"git dft\"
 alias gha=\"act\"
+alias gha3=\"act3\"
 
 # Containers & K8s
 alias lzd=\"lazydocker\"
@@ -7773,6 +7869,11 @@ alias loadtest=\"oha\"
 alias par=\"parallel\"
 alias lint-sh=\"shellcheck\"
 alias fmt-sh=\"shfmt -w -i 4\"
+
+# Terminal apps
+alias n=\"nnn -de\"
+alias prog=\"progress -m\"
+alias sshc=\"sshclick\"
 
 # Directory Shortcuts
 alias cw=\"z ~/Code/work\"

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -2873,6 +2873,103 @@ MPV_CONF
     success "mpv configured (hardware accel, save position, screenshots)"
 fi
 
+# ---- cmus config ----
+CMUS_CONFIG_DIR="$HOME/.config/cmus"
+CMUS_CONFIG="$CMUS_CONFIG_DIR/rc"
+if [[ -f "$CMUS_CONFIG" ]]; then
+    warn "cmus config already exists"
+else
+    info "Creating cmus config (Dracula-inspired colors, sensible defaults)..."
+    mkdir -p "$CMUS_CONFIG_DIR"
+    cat > "$CMUS_CONFIG" <<'CMUS_CONF'
+# cmus configuration — Dracula-inspired colors
+# Apply inside cmus with:  :source ~/.config/cmus/rc
+
+# Replay gain (consistent volume across tracks)
+set replaygain=track
+set replaygain_limit=true
+
+# Display formats
+set format_current= %a — %t
+set format_playlist= %-20%a %t (%l)
+set format_trackwin= %-20%a %t (%l)
+
+# Colors (Dracula palette, 256-color)
+set color_bg=-1
+set color_cmdline_bg=-1
+set color_cmdline_fg=253
+set color_info=141
+set color_error=203
+set color_separator=61
+set color_statusline_bg=61
+set color_statusline_fg=253
+set color_titleline_bg=61
+set color_titleline_fg=253
+set color_win_bg=-1
+set color_win_cur=141
+set color_win_cur_sel_bg=61
+set color_win_cur_sel_fg=253
+set color_win_dir=117
+set color_win_fg=253
+set color_win_inactive_cur_sel_bg=61
+set color_win_inactive_cur_sel_fg=253
+set color_win_inactive_sel_bg=-1
+set color_win_inactive_sel_fg=141
+set color_win_sel_bg=61
+set color_win_sel_fg=253
+set color_win_title_bg=61
+set color_win_title_fg=253
+CMUS_CONF
+    success "cmus configured (Dracula colors, replaygain)"
+fi
+
+# ---- w3m config ----
+W3M_CONFIG_DIR="$HOME/.w3m"
+W3M_CONFIG="$W3M_CONFIG_DIR/config"
+if [[ -f "$W3M_CONFIG" ]]; then
+    warn "w3m config already exists"
+else
+    info "Creating w3m config (UTF-8, cookies off, colors)..."
+    mkdir -p "$W3M_CONFIG_DIR"
+    cat > "$W3M_CONFIG" <<'W3M_CONF'
+# w3m configuration — sensible privacy + display defaults
+display_charset UTF-8
+document_charset UTF-8
+system_charset UTF-8
+auto_detect 2
+
+# Rendering
+display_image 0
+use_mouse 1
+tabstop 8
+show_lnum 0
+
+# Colors
+color 1
+basic_color terminal
+anchor_color blue
+image_color green
+form_color red
+mark_color cyan
+
+# Privacy — disable cookies by default
+use_cookie 0
+accept_cookie 0
+show_cookie 0
+
+# Don't follow redirects silently
+follow_redirection 5
+
+# Proxy — inherit from env (http_proxy, https_proxy)
+use_proxy 1
+
+# Bookmarks
+bookmark bookmark.html
+keep_cache_in_memory 0
+W3M_CONF
+    success "w3m configured (UTF-8, cookies off)"
+fi
+
 # ---- nushell config ----
 NUSHELL_CONFIG_DIR="$HOME/Library/Application Support/nushell"
 NUSHELL_ENV="$NUSHELL_CONFIG_DIR/env.nu"
@@ -6922,6 +7019,12 @@ export FZF_CTRL_T_OPTS="--preview 'bat --color=always --style=numbers --line-ran
 export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'
 export FZF_ALT_C_OPTS="--preview 'eza --tree --icons --level=2 --color=always {}' --preview-window='right:50%:wrap'"
 
+# -- nnn (terminal file manager) ----------------------------------------------
+export NNN_OPTS="deH"
+export NNN_COLORS="2136"
+export NNN_FCOLORS="c1e2272e006033f7c6d6abc4"
+export NNN_PLUG="f:fzcd;o:fzopen;p:preview-tui"
+
 # zsh plugins
 if type brew &>/dev/null; then
     _brew_prefix="$(brew --prefix)"
@@ -6982,6 +7085,7 @@ alias lg="lazygit"
 alias ghd="gh dash"
 alias gdft="git dft"
 alias gha="act"
+alias gha3="act3"
 
 # -- Containers & Kubernetes --------------------------------------------------
 alias lzd="lazydocker"
@@ -7017,6 +7121,10 @@ alias loadtest="oha"
 alias par="parallel"
 alias lint-sh="shellcheck"
 alias fmt-sh="shfmt -w -i 4"
+
+# -- Terminal Apps ------------------------------------------------------------
+alias n="nnn -de"
+alias prog="progress -m"
 
 # -- Directory Shortcuts (using zoxide for smart jumping) --------------------
 alias cw="z ~/Code/work"

--- a/scripts/setup-dev-tools-windows.ps1
+++ b/scripts/setup-dev-tools-windows.ps1
@@ -5969,6 +5969,7 @@ function serve { miniserve --color-scheme-dark dracula -qr . @args }
 function ghd { gh dash @args }
 function gdft { git dft @args }
 function gha { act @args }
+function gha3 { act3 @args }
 
 # -- Media & Conversion -------------------------------------------------------
 function ytdl { yt-dlp @args }


### PR DESCRIPTION
Follow-up to #3. Closes #4.

## Summary
Extend user-facing surfaces for the seven CLI tools added in #3:
- Usage documentation in all three platform guides
- New shell aliases (gha3, n, prog, sshc) and corresponding shortcuts-doc rows
- Default tool configs for cmus and w3m (Dracula + privacy defaults)
- nnn env vars in the managed zshrc block

## Changes

### Docs (guides)
- \`docs/GUIDE-MACOS.md\`, \`docs/GUIDE-LINUX.md\`, \`docs/GUIDE-WINDOWS.md\`:
  - add **act3** under Code Quality
  - add **w3m**, **monolith** under Media & Files (plus **cmus** there)
  - add **nnn** under Daily Workflow → File Navigation
  - add **progress** under Daily Workflow → File Operations
  - add **sshclick** under Networking & Debugging (Linux only)

### Docs (shortcuts)
- \`docs/SHORTCUTS-*.md\`: new \`gha3\` row; mac+linux get a new "Terminal Apps" table with \`n\`, \`prog\` (and \`sshc\` on Linux)

### Aliases (zshrc managed block)
| Alias | Runs | Platforms |
|-------|------|-----------|
| \`gha3\` | \`act3\` | mac, linux, windows |
| \`n\` | \`nnn -de\` | mac, linux |
| \`prog\` | \`progress -m\` | mac, linux |
| \`sshc\` | \`sshclick\` | linux |

### Configs (generated only if not already present)
- \`~/.config/cmus/rc\` — Dracula 256-color palette + replaygain (mac, linux)
- \`~/.w3m/config\` — UTF-8, cookies off, color display (mac, linux)
- Exports added to zshrc (mac, linux): \`NNN_OPTS=\"deH\"\`, \`NNN_COLORS=\"2136\"\`, \`NNN_FCOLORS=...\`, \`NNN_PLUG=\"f:fzcd;o:fzopen;p:preview-tui\"\`

### Not configured
- **monolith**, **progress**, **sshclick** — CLI-only, no user config
- **act3** — requires user-specific workflow list in \`~/.config/act3/act3.yml\`; users add their own

## Test plan
- [ ] \`bash -n scripts/setup-dev-tools-mac.sh\` passes (verified locally)
- [ ] \`bash -n scripts/setup-dev-tools-linux.sh\` passes (verified locally)
- [ ] CI PSScriptAnalyzer passes on Windows script
- [ ] \`./scripts/setup-dev-tools-mac.sh --dry-run --only configs\` shows cmus and w3m config steps
- [ ] After install, \`cmus\` launches with Dracula theme and \`w3m\` loads with cookies disabled
- [ ] \`echo \$NNN_OPTS\` prints \`deH\` in a new shell
- [ ] \`alias gha3\` prints \`act3\` in a new shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)