### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2.1.0] - 2026-04-13
+
+### Features
+
+- **browsers**: Add Carbonyl (Chromium-based terminal browser) to mac/linux/windows browsers categories (#1)
+- **tools**: Add seven terminal CLI tools across platforms (#3):
+  - `w3m` and `monolith` in browsers
+  - `cmus` in media
+  - `nnn` and `progress` in terminal-productivity (mac + linux)
+  - `act3` in code-quality
+  - `sshclick` in networking (linux only)
+- **aliases**: Add `gha3` → `act3` (all platforms); `n` → `nnn -de`, `prog` → `progress -m` (mac + linux); `sshc` → `sshclick` (linux) (#5)
+- **configs**: Generate default `~/.config/cmus/rc` (Dracula palette, replaygain) and `~/.w3m/config` (UTF-8, cookies off) on mac + linux (#5)
+- **configs**: Export `NNN_OPTS`, `NNN_COLORS`, `NNN_FCOLORS`, `NNN_PLUG` in managed zshrc block (#5)
+
+### Documentation
+
+- Document all new tools in `GUIDE-MACOS.md`, `GUIDE-LINUX.md`, `GUIDE-WINDOWS.md` with usage examples (#5)
+- Update `SHORTCUTS-*.md` with new alias rows and a "Terminal Apps" section (#5)
+
 ## [Unreleased]
 
 ### Bug Fixes

--- a/scripts/setup-dev-tools-linux.sh
+++ b/scripts/setup-dev-tools-linux.sh
@@ -3,14 +3,14 @@
 # =============================================================================
 # Development Environment Setup Script (Linux)
 # =============================================================================
-# Version:  2.0.0
+# Version:  2.1.0
 # Updated:  2026-04-06
 # Platform: Linux (Ubuntu/Debian, Fedora/RHEL, Arch/Manjaro)
 # Run:      chmod +x setup-dev-tools-linux.sh && ./setup-dev-tools-linux.sh
 # Flags:    --dry-run, --skip <categories>, --only <categories>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="2.0.0"
+SCRIPT_VERSION="2.1.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -3,14 +3,14 @@
 # =============================================================================
 # Development Environment Setup Script (macOS)
 # =============================================================================
-# Version:  2.0.0
+# Version:  2.1.0
 # Updated:  2026-04-05
 # Platform: macOS (Apple Silicon + Intel)
 # Run:      chmod +x setup-dev-tools.sh && ./setup-dev-tools.sh
 # Flags:    --dry-run, --list, --skip <cats>, --only <cats>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="2.0.0"
+SCRIPT_VERSION="2.1.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 

--- a/scripts/setup-dev-tools-windows.ps1
+++ b/scripts/setup-dev-tools-windows.ps1
@@ -1,7 +1,7 @@
 # =============================================================================
 # Development Environment Setup Script (Windows)
 # =============================================================================
-# Version:  2.0.0
+# Version:  2.1.0
 # Updated:  2026-04-06
 # Platform: Windows 10/11 (x64)
 # Run:      Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
@@ -9,7 +9,7 @@
 # Flags:    --dry-run, --skip <categories>, --only <categories>, --cleanup, --help
 # =============================================================================
 
-$SCRIPT_VERSION = "2.0.0"
+$SCRIPT_VERSION = "2.1.0"
 $SCRIPT_START = Get-Date
 
 # Don't abort on errors — we count failures instead


### PR DESCRIPTION
## Summary
Prep the v2.1.0 release — bumps `SCRIPT_VERSION` in all three install scripts and adds a CHANGELOG entry summarizing recent PRs.

## Included in v2.1.0
- #1 feat(browsers): add Carbonyl terminal browser
- #3 feat(tools): add w3m, monolith, cmus, nnn, progress, act3, sshclick
- #5 feat(docs,configs): docs, aliases, and configs for the new tools

## Release flow
Once merged, tag \`v2.1.0\` on main. The \`release.yml\` workflow builds per-platform zips and auto-generates notes.

## Test plan
- [x] \`bash -n\` passes on both bash scripts
- [ ] CI lint passes
- [ ] After merge + tag: release workflow produces three zip artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)