### PR TITLE
chore(tools): replace Bruno with Postman, remove Zed editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 
 | Tool | Description |
 |------|-------------|
-| **Bruno** | Open-source API client -- Postman alternative, stores in git |
+| **Postman** | Industry-standard API client -- collections, environments, scripting |
 | **grpcurl** | curl for gRPC services |
 
 ---
@@ -375,7 +375,6 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 | **atuin** | Replaces shell history with SQLite-backed, fuzzy-searchable database |
 | **mise** | Universal version manager -- Node, Python, Go, Ruby all in one (replaces nvm + pyenv + rbenv) |
 | **VS Code** | Primary code editor and IDE |
-| **Zed** | Fast native editor from ex-Atom team -- GPU-rendered |
 | **Claude Code** | AI-assisted coding in the terminal |
 | **GitHub Copilot CLI** | AI suggestions in the terminal (via `gh copilot suggest`) |
 | **chezmoi** | Dotfile manager -- backup and restore configs across machines |
@@ -542,7 +541,6 @@ Applied consistently across all tools:
 | Tool | How |
 |------|-----|
 | **VS Code** | Extension auto-installed, set as default theme |
-| **Zed** | Dracula theme set in settings.json |
 | **bat** | Dracula syntax theme in config |
 | **delta** | Dracula syntax theme for git diffs |
 | **Ghostty** | Full 16-color Dracula palette in config |
@@ -804,7 +802,6 @@ The script generates config files with sensible defaults:
 | `~/.newsboat/urls` | newsboat | Starter RSS feeds (Claude Code, Node, Rust, GitHub) |
 | `~/Library/Application Support/nushell/env.nu` | nushell | Starship prompt, Homebrew paths |
 | `~/.config/ghostty/config` | Ghostty | JetBrains Mono, Dracula palette, transparent titlebar |
-| `~/.config/zed/settings.json` | Zed | Dracula theme, JetBrains Mono, format on save, relative line numbers, inline blame, no telemetry |
 | `~/.config/fastfetch/config.jsonc` | fastfetch | Nerd Font icons, package counts, Node/Python/Go/Rust/Docker versions, battery, disk, colored output |
 | `~/.config/mise/config.toml` | mise | Auto-install, trust ~/Code |
 | `~/.config/topgrade.toml` | topgrade | Cleanup, greedy cask updates |
@@ -1225,7 +1222,7 @@ These 150+ CLI tools and configs are installed on every platform:
 
 **Database:** pgcli, mycli, lazysql, usql, sq, dbmate
 
-**Editors:** VS Code, Zed
+**Editors:** VS Code
 
 **JS tooling:** TypeScript, tsx, Turborepo, Lighthouse, Mermaid CLI
 
@@ -1234,7 +1231,7 @@ These 150+ CLI tools and configs are installed on every platform:
 ## 60+ Shared Config Files
 
 Identical content across all platforms (paths adjusted per OS):
-starship, atuin, glow, btop, lazygit, lazydocker, k9s, yazi, gh-dash, stern, mise, fastfetch, direnv, caddy, ngrok, yt-dlp, asciinema, pgcli, zed, ghostty, .editorconfig, .prettierrc, .shellcheckrc, .curlrc, .npmrc, .ripgreprc, .fdignore, .vimrc, .nanorc, .gitignore_global, .gitmessage, .myclirc, .gemrc, .actrc, .mlrrc, .justfile, VS Code settings/keybindings/extensions, Docker, AWS CLI, GitHub CLI, pip, git global config, SSH config, Claude Code config (settings, CLAUDE.md, 6 rules, 3 hooks, 10 commands)
+starship, atuin, glow, btop, lazygit, lazydocker, k9s, yazi, gh-dash, stern, mise, fastfetch, direnv, caddy, ngrok, yt-dlp, asciinema, pgcli, ghostty, .editorconfig, .prettierrc, .shellcheckrc, .curlrc, .npmrc, .ripgreprc, .fdignore, .vimrc, .nanorc, .gitignore_global, .gitmessage, .myclirc, .gemrc, .actrc, .mlrrc, .justfile, VS Code settings/keybindings/extensions, Docker, AWS CLI, GitHub CLI, pip, git global config, SSH config, Claude Code config (settings, CLAUDE.md, 6 rules, 3 hooks, 10 commands)
 
 ---
 

--- a/docs/GUIDE-LINUX.md
+++ b/docs/GUIDE-LINUX.md
@@ -1031,19 +1031,13 @@ Already configured by the script. Additional recommended steps:
 2. **GitHub Copilot:** Install extension, sign in with GitHub
 3. **Keyboard shortcuts:** The script installs 21 keybindings (see SHORTCUTS.md)
 
-### Zed
+### Postman (API Client)
 
-Already configured by the script with Dracula theme. Additional:
-1. **Sign in:** Zed > Sign In for collaboration features
-2. **AI integration:** Settings > AI > configure Claude or Copilot
-3. **Vim mode:** Already enabled by default in script config
-
-### Bruno (API Client)
-
-1. **Create a collection:** New Collection > choose a directory (git-friendly)
-2. **Import from Postman:** Collection > Import > Postman Collection
-3. **Environment variables:** Environments > add dev/staging/prod configs
-4. **Tests:** Each request supports pre-request and post-response scripts
+1. **Sign in:** Sign in with your Postman account to sync collections across devices
+2. **Create a collection:** New > Collection > organize requests by service or feature
+3. **Environments:** Environments tab > add dev/staging/prod with variables
+4. **Tests:** Each request supports pre-request and test scripts (Tests tab)
+5. **Import:** File > Import supports OpenAPI, cURL, and other Postman exports
 
 ### Notion
 

--- a/docs/GUIDE-MACOS.md
+++ b/docs/GUIDE-MACOS.md
@@ -874,13 +874,6 @@ Already configured by the script. Additional recommended steps:
 2. **GitHub Copilot:** Install extension, sign in with GitHub
 3. **Keyboard shortcuts:** The script installs 21 keybindings (see SHORTCUTS.md)
 
-### Zed
-
-Already configured by the script with Dracula theme. Additional:
-1. **Sign in:** Zed > Sign In for collaboration features
-2. **AI integration:** Settings > AI > configure Claude or Copilot
-3. **Vim mode:** Already enabled by default in script config
-
 ### TablePlus
 
 1. **Add connections:** Click "+" to add database connections
@@ -888,12 +881,13 @@ Already configured by the script with Dracula theme. Additional:
 3. **Theme:** Preferences > Appearance > Dark mode
 4. **Export:** Right-click table > Export (CSV, JSON, SQL)
 
-### Bruno (API Client)
+### Postman (API Client)
 
-1. **Create a collection:** New Collection > choose a directory (git-friendly)
-2. **Import from Postman:** Collection > Import > Postman Collection
-3. **Environment variables:** Environments > add dev/staging/prod configs
-4. **Tests:** Each request supports pre-request and post-response scripts
+1. **Sign in:** Sign in with your Postman account to sync collections across devices
+2. **Create a collection:** New > Collection > organize requests by service or feature
+3. **Environments:** Environments tab > add dev/staging/prod with variables
+4. **Tests:** Each request supports pre-request and test scripts (Tests tab)
+5. **Import:** File > Import supports OpenAPI, cURL, and other Postman exports
 
 ### Notion
 

--- a/docs/GUIDE-WINDOWS.md
+++ b/docs/GUIDE-WINDOWS.md
@@ -1030,13 +1030,6 @@ Already configured by the script. Additional recommended steps:
 2. **GitHub Copilot:** Install extension, sign in with GitHub
 3. **Keyboard shortcuts:** The script installs 21 keybindings (see SHORTCUTS.md)
 
-### Zed
-
-Already configured by the script with Dracula theme. Additional:
-1. **Sign in:** Zed > Sign In for collaboration features
-2. **AI integration:** Settings > AI > configure Claude or Copilot
-3. **Vim mode:** Already enabled by default in script config
-
 ### TablePlus
 
 1. **Add connections:** Click "+" to add database connections
@@ -1044,12 +1037,13 @@ Already configured by the script with Dracula theme. Additional:
 3. **Theme:** Preferences > Appearance > Dark mode
 4. **Export:** Right-click table > Export (CSV, JSON, SQL)
 
-### Bruno (API Client)
+### Postman (API Client)
 
-1. **Create a collection:** New Collection > choose a directory (git-friendly)
-2. **Import from Postman:** Collection > Import > Postman Collection
-3. **Environment variables:** Environments > add dev/staging/prod configs
-4. **Tests:** Each request supports pre-request and post-response scripts
+1. **Sign in:** Sign in with your Postman account to sync collections across devices
+2. **Create a collection:** New > Collection > organize requests by service or feature
+3. **Environments:** Environments tab > add dev/staging/prod with variables
+4. **Tests:** Each request supports pre-request and test scripts (Tests tab)
+5. **Import:** File > Import supports OpenAPI, cURL, and other Postman exports
 
 ### Notion
 

--- a/scripts/setup-dev-tools-linux.sh
+++ b/scripts/setup-dev-tools-linux.sh
@@ -225,9 +225,9 @@ list_categories() {
     printf "  %-25s %s\n" "k8s-github"          "stern, gh-dash"
     printf "  %-25s %s\n" "database"            "pgcli, mycli, lazysql, usql, sq"
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
-    printf "  %-25s %s\n" "api"                 "Bruno, grpcurl"
+    printf "  %-25s %s\n" "api"                 "Postman, grpcurl"
     printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap, sshclick"
-    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, VS Code, Zed, Alacritty, tmux"
+    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, VS Code, Alacritty, tmux"
     printf "  %-25s %s\n" "ui"                  "Storybook, Playwright, Chrome"
     printf "  %-25s %s\n" "ux"                  "Lighthouse"
     printf "  %-25s %s\n" "docs"                "d2, Mermaid CLI"
@@ -2537,10 +2537,10 @@ fi  # containers
 if should_run "api"; then
 banner "API Development"
 
-# Bruno
-snap_install "bruno" "Bruno (open-source API client)" ""
-if ! installed bruno && ! snap list bruno &>/dev/null; then
-    flatpak_install "com.usebruno.Bruno" "Bruno (open-source API client)"
+# Postman
+snap_install "postman" "Postman (industry-standard API client)" ""
+if ! installed postman && ! snap list postman &>/dev/null; then
+    flatpak_install "com.getpostman.Postman" "Postman (industry-standard API client)"
 fi
 
 # grpcurl
@@ -2643,31 +2643,7 @@ if ! installed code && [[ "$PKG_MANAGER" == "pacman" ]]; then
     snap_install "code" "VS Code" "classic"
 fi
 
-# Cursor removed (paid) — use VS Code + Zed
-
-# Zed
-if ! installed zed; then
-    info "Installing Zed editor..."
-    if [[ "$DRY_RUN" != "true" ]]; then
-        installer
-        installer="$(mktemp)"
-        curl -fsSL https://zed.dev/install.sh -o "$installer" 2>/dev/null
-        if [[ ! -s "$installer" ]]; then
-            error "Failed to download Zed installer"
-            rm -f "$installer"
-        else
-            sh "$installer" >> "$LOG_FILE" 2>&1 || true
-            rm -f "$installer"
-        fi
-        if installed zed; then
-            success "Zed installed"
-        else
-            flatpak_install "dev.zed.Zed" "Zed editor"
-        fi
-    fi
-else
-    warn "Zed already installed"
-fi
+# Cursor removed (paid) — use VS Code
 
 # Alacritty
 pkg_install "alacritty" "alacritty" "alacritty" "Alacritty (GPU-accelerated terminal)"
@@ -5574,42 +5550,6 @@ FASTFETCH_CONF
     success "fastfetch configured (themed layout, Nerd Font icons, dev tool versions)"
 fi
 
-# ---- Zed editor config ----
-ZED_CONFIG_DIR="$HOME/.config/zed"
-ZED_CONFIG="$ZED_CONFIG_DIR/settings.json"
-if [[ -f "$ZED_CONFIG" ]]; then
-    warn "Zed config already exists"
-else
-    info "Creating Zed configuration..."
-    mkdir -p "$ZED_CONFIG_DIR"
-    cat > "$ZED_CONFIG" <<'ZED_CONF'
-{
-    "theme": "Dracula",
-    "ui_font_family": "Inter",
-    "ui_font_size": 15,
-    "buffer_font_family": "JetBrains Mono",
-    "buffer_font_size": 14,
-    "buffer_line_height": { "custom": 1.6 },
-    "buffer_font_features": { "calt": true, "liga": true },
-    "tab_size": 2,
-    "format_on_save": "on",
-    "autosave": "on_focus_change",
-    "relative_line_numbers": true,
-    "scrollbar": { "show": "auto" },
-    "indent_guides": { "enabled": true, "coloring": "indent_aware" },
-    "inlay_hints": { "enabled": true },
-    "git": { "inline_blame": { "enabled": true } },
-    "terminal": {
-        "font_family": "JetBrains Mono NF",
-        "font_size": 13,
-        "blinking": "on"
-    },
-    "telemetry": { "diagnostics": false, "metrics": false }
-}
-ZED_CONF
-    success "Zed configured (Dracula theme, JetBrains Mono, format on save)"
-fi
-
 # ---- direnv config ----
 DIRENV_CONFIG_DIR="$HOME/.config/direnv"
 DIRENV_CONFIG="$DIRENV_CONFIG_DIR/direnv.toml"
@@ -6098,7 +6038,7 @@ else
 
 ## Environment
 - Shell: zsh with starship prompt, atuin history, fzf fuzzy finder, zsh-autosuggestions, zsh-syntax-highlighting
-- Editor: VS Code / Zed (Dracula theme, JetBrains Mono)
+- Editor: VS Code (Dracula theme, JetBrains Mono)
 - Terminal: Ghostty (Dracula theme)
 - Package managers: pnpm (preferred), npm, bun
 - Python: uv for packages (not pip), ruff for linting (not flake8/black)
@@ -6109,7 +6049,7 @@ else
 - Shell note: `bat` is aliased to `cat`; use `/bin/cat` only inside heredoc subshells where bat breaks syntax
 - Dotfiles: chezmoi
 - Launcher: Raycast
-- API client: Bruno
+- API client: Postman
 - Database GUI: TablePlus
 - Proxy/debugger: mitmproxy
 - Tunneling: ngrok

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -238,9 +238,9 @@ list_categories() {
     printf "  %-25s %s\n" "k8s-github"          "stern, gh-dash"
     printf "  %-25s %s\n" "database"            "pgcli, mycli, usql, sq, TablePlus"
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
-    printf "  %-25s %s\n" "api"                 "Bruno, grpcurl"
+    printf "  %-25s %s\n" "api"                 "Postman, grpcurl"
     printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap"
-    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, VS Code, Zed, Ghostty, zellij, Raycast"
+    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, VS Code, Ghostty, zellij, Raycast"
     printf "  %-25s %s\n" "ux"                  "Lighthouse"
     printf "  %-25s %s\n" "docs"                "d2, Mermaid CLI"
     printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins"
@@ -1336,7 +1336,7 @@ fi  # containers
 if should_run "api"; then
 banner "API Development"
 
-brew_cask_install "bruno" "Bruno (open-source API client, git-friendly)"
+brew_cask_install "postman" "Postman (industry-standard API client)"
 brew_install "grpcurl" "grpcurl (curl for gRPC)"
 
 fi  # api
@@ -1377,7 +1377,6 @@ if [[ -f "$VSCODE_CLI" ]] && ! installed code; then
     ln -sf "$VSCODE_CLI" /usr/local/bin/code 2>/dev/null || \
     sudo ln -sf "$VSCODE_CLI" /usr/local/bin/code 2>/dev/null || true
 fi
-brew_cask_install "zed" "Zed (fast native editor from ex-Atom team — GPU-rendered)"
 brew_cask_install "ghostty" "Ghostty (fast GPU-accelerated terminal)"
 brew_install "zellij" "zellij (modern terminal multiplexer — discoverable UI, layouts)"
 
@@ -4724,42 +4723,6 @@ GHOSTTY_CONF
     success "Ghostty configured (JetBrains Mono, Dracula theme, transparent titlebar)"
 fi
 
-# ---- Zed editor config ----
-ZED_CONFIG_DIR="$HOME/.config/zed"
-ZED_CONFIG="$ZED_CONFIG_DIR/settings.json"
-if [[ -f "$ZED_CONFIG" ]]; then
-    warn "Zed config already exists"
-else
-    info "Creating Zed configuration..."
-    mkdir -p "$ZED_CONFIG_DIR"
-    cat > "$ZED_CONFIG" <<'ZED_CONF'
-{
-    "theme": "Dracula",
-    "ui_font_family": "Inter",
-    "ui_font_size": 15,
-    "buffer_font_family": "JetBrains Mono",
-    "buffer_font_size": 14,
-    "buffer_line_height": { "custom": 1.6 },
-    "buffer_font_features": { "calt": true, "liga": true },
-    "tab_size": 2,
-    "format_on_save": "on",
-    "autosave": "on_focus_change",
-    "relative_line_numbers": true,
-    "scrollbar": { "show": "auto" },
-    "indent_guides": { "enabled": true, "coloring": "indent_aware" },
-    "inlay_hints": { "enabled": true },
-    "git": { "inline_blame": { "enabled": true } },
-    "terminal": {
-        "font_family": "JetBrains Mono NF",
-        "font_size": 13,
-        "blinking": "on"
-    },
-    "telemetry": { "diagnostics": false, "metrics": false }
-}
-ZED_CONF
-    success "Zed configured (Dracula theme, JetBrains Mono, format on save)"
-fi
-
 # ---- direnv config ----
 DIRENV_CONFIG_DIR="$HOME/.config/direnv"
 DIRENV_CONFIG="$DIRENV_CONFIG_DIR/direnv.toml"
@@ -6083,7 +6046,7 @@ else
 
 ## Environment
 - Shell: zsh with starship prompt, atuin history, fzf fuzzy finder, zsh-autosuggestions, zsh-syntax-highlighting
-- Editor: VS Code / Zed (Dracula theme, JetBrains Mono)
+- Editor: VS Code (Dracula theme, JetBrains Mono)
 - Terminal: Ghostty (Dracula theme)
 - Package managers: pnpm (preferred), npm, bun
 - Python: uv for packages (not pip), ruff for linting (not flake8/black)
@@ -6094,7 +6057,7 @@ else
 - Shell note: `bat` is aliased to `cat`; use `/bin/cat` only inside heredoc subshells where bat breaks syntax
 - Dotfiles: chezmoi
 - Launcher: Raycast
-- API client: Bruno
+- API client: Postman
 - Database GUI: TablePlus
 - Proxy/debugger: mitmproxy
 - Tunneling: ngrok

--- a/scripts/setup-dev-tools-windows.ps1
+++ b/scripts/setup-dev-tools-windows.ps1
@@ -235,9 +235,9 @@ function Show-Categories {
         @("k8s-github",            "stern, gh-dash")
         @("database",              "pgcli, mycli, usql, sq, DBeaver")
         @("containers",            "lazydocker, dive, kubectl, k9s")
-        @("api",                   "Bruno, grpcurl")
+        @("api",                   "Postman, grpcurl")
         @("networking",            "mtr/WinMTR, bandwhich, nmap")
-        @("dx",                    "fzf, starship, atuin, VS Code, Zed, Alacritty, PowerToys")
+        @("dx",                    "fzf, starship, atuin, VS Code, Alacritty, PowerToys")
         @("ui",                    "Storybook, Playwright, Chrome")
         @("ux",                    "Lighthouse")
         @("docs",                  "d2, Mermaid CLI")
@@ -1111,7 +1111,7 @@ Install-ScoopPackage "k9s" "k9s (terminal UI for Kubernetes)"
 if (Test-ShouldRun "api") {
 Write-Banner "API Development"
 
-Install-WingetPackage "Bruno.Bruno" "Bruno (open-source API client, git-friendly)"
+Install-WingetPackage "Postman.Postman" "Postman (industry-standard API client)"
 Install-ScoopPackage "grpcurl" "grpcurl (curl for gRPC)"
 
 } # api
@@ -1140,9 +1140,6 @@ Install-ScoopPackage "chezmoi" "chezmoi (dotfile manager -- backup/restore confi
 # Editors & terminals
 Install-WingetPackage "Microsoft.VisualStudioCode" "VS Code"
 Install-ScoopPackage "alacritty" "Alacritty (fast GPU-accelerated terminal)"
-
-# Zed
-Write-Info "Zed: Check availability at https://zed.dev for Windows"
 
 # Windows Terminal is built-in on Windows 11 / available via winget
 Install-WingetPackage "Microsoft.WindowsTerminal" "Windows Terminal"
@@ -3531,44 +3528,6 @@ loc:
     }
 }
 
-# ---- Zed editor config ----
-$zedConfigDir = Join-Path $HOME ".config\zed"
-$zedConfig = Join-Path $zedConfigDir "settings.json"
-if (Test-Path $zedConfig) {
-    Write-Warn "Zed config already exists"
-} else {
-    if (-not $DRY_RUN) {
-        Write-Info "Creating Zed configuration..."
-        if (-not (Test-Path $zedConfigDir)) { New-Item -ItemType Directory -Path $zedConfigDir -Force | Out-Null }
-        Set-Content -Path $zedConfig -Value @"
-{
-    "theme": "Dracula",
-    "ui_font_family": "Inter",
-    "ui_font_size": 15,
-    "buffer_font_family": "JetBrains Mono",
-    "buffer_font_size": 14,
-    "buffer_line_height": { "custom": 1.6 },
-    "buffer_font_features": { "calt": true, "liga": true },
-    "tab_size": 2,
-    "format_on_save": "on",
-    "autosave": "on_focus_change",
-    "relative_line_numbers": true,
-    "scrollbar": { "show": "auto" },
-    "indent_guides": { "enabled": true, "coloring": "indent_aware" },
-    "inlay_hints": { "enabled": true },
-    "git": { "inline_blame": { "enabled": true } },
-    "terminal": {
-        "font_family": "JetBrains Mono NF",
-        "font_size": 13,
-        "blinking": "on"
-    },
-    "telemetry": { "diagnostics": false, "metrics": false }
-}
-"@
-        Write-Success "Zed configured (Dracula theme, JetBrains Mono, format on save)"
-    }
-}
-
 # ---- direnv config ----
 $direnvConfigDir = Join-Path $HOME ".config\direnv"
 $direnvConfig = Join-Path $direnvConfigDir "direnv.toml"
@@ -4978,7 +4937,7 @@ if (Test-Path $claudeMd) {
 
 ## Environment
 - Shell: PowerShell with Starship prompt
-- Editor: VS Code / Zed (Dracula theme, JetBrains Mono)
+- Editor: VS Code (Dracula theme, JetBrains Mono)
 - Terminal: Windows Terminal / Alacritty (Dracula theme)
 - Package managers: pnpm (preferred), npm, bun
 - Python: uv for packages (not pip), ruff for linting (not flake8/black)


### PR DESCRIPTION
## Summary
- Replace Bruno with Postman as the API client across mac/linux/windows install scripts
- Remove Zed editor entirely (install + Dracula `settings.json` config blocks on all three platforms)
- Update README tool tables, Dracula list, config-files list, summary categories
- Update per-platform GUIDE docs setup sections (drop Zed, swap Bruno → Postman)

## Changes
- `scripts/setup-dev-tools-mac.sh`: `brew_cask_install postman` (replaces bruno); drop Zed cask install + settings.json heredoc
- `scripts/setup-dev-tools-linux.sh`: `snap/flatpak postman` (com.getpostman.Postman); drop Zed installer block + settings.json heredoc
- `scripts/setup-dev-tools-windows.ps1`: `winget Postman.Postman` (replaces Bruno.Bruno); drop Zed availability notice + settings.json here-string
- `README.md`: update API table, Developer Experience table, Dracula table, config-files table, Editors line, shared-config list
- `docs/GUIDE-{MACOS,LINUX,WINDOWS}.md`: replace Bruno setup steps with Postman setup steps; remove Zed setup section

Net diff: +39 / -198 across 7 files.

## Test plan
- [ ] `bash -n` passes on mac/linux scripts (verified locally)
- [ ] No remaining `bruno`/`zed` references anywhere in repo (verified via grep)
- [ ] On a fresh macOS box, `./scripts/setup-dev-tools-mac.sh --only api` installs Postman
- [ ] On a fresh Linux box, `./scripts/setup-dev-tools-linux.sh --only api` installs Postman via snap or flatpak
- [ ] On a fresh Windows box, `./scripts/setup-dev-tools-windows.ps1 --only api` installs Postman via winget
- [ ] No Zed install attempted on any platform; no `~/.config/zed/settings.json` created

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)