### PR TITLE
chore(release): bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.2.0] - 2026-04-23
+
+### Changed
+
+- **api**: Replace Bruno with Postman as the API client across mac (brew cask `postman`), linux (snap/flatpak `com.getpostman.Postman`), and windows (winget `Postman.Postman`) (#8)
+
+### Removed
+
+- **editors**: Remove Zed editor install and `~/.config/zed/settings.json` config block from all three setup scripts; VS Code is now the sole configured editor (#8)
+
 ## [2.1.0] - 2026-04-13
 
 ### Features

--- a/scripts/setup-dev-tools-linux.sh
+++ b/scripts/setup-dev-tools-linux.sh
@@ -3,14 +3,14 @@
 # =============================================================================
 # Development Environment Setup Script (Linux)
 # =============================================================================
-# Version:  2.1.0
+# Version:  2.2.0
 # Updated:  2026-04-06
 # Platform: Linux (Ubuntu/Debian, Fedora/RHEL, Arch/Manjaro)
 # Run:      chmod +x setup-dev-tools-linux.sh && ./setup-dev-tools-linux.sh
 # Flags:    --dry-run, --skip <categories>, --only <categories>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="2.1.0"
+SCRIPT_VERSION="2.2.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -3,14 +3,14 @@
 # =============================================================================
 # Development Environment Setup Script (macOS)
 # =============================================================================
-# Version:  2.1.0
+# Version:  2.2.0
 # Updated:  2026-04-05
 # Platform: macOS (Apple Silicon + Intel)
 # Run:      chmod +x setup-dev-tools.sh && ./setup-dev-tools.sh
 # Flags:    --dry-run, --list, --skip <cats>, --only <cats>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="2.1.0"
+SCRIPT_VERSION="2.2.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 

--- a/scripts/setup-dev-tools-windows.ps1
+++ b/scripts/setup-dev-tools-windows.ps1
@@ -1,7 +1,7 @@
 # =============================================================================
 # Development Environment Setup Script (Windows)
 # =============================================================================
-# Version:  2.1.0
+# Version:  2.2.0
 # Updated:  2026-04-06
 # Platform: Windows 10/11 (x64)
 # Run:      Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
@@ -9,7 +9,7 @@
 # Flags:    --dry-run, --skip <categories>, --only <categories>, --cleanup, --help
 # =============================================================================
 
-$SCRIPT_VERSION = "2.1.0"
+$SCRIPT_VERSION = "2.2.0"
 $SCRIPT_START = Get-Date
 
 # Don't abort on errors — we count failures instead


### PR DESCRIPTION
## Summary
- Bump `SCRIPT_VERSION` from `2.1.0` → `2.2.0` in mac/linux/windows setup scripts
- Add `[2.2.0]` section to `CHANGELOG.md` documenting the Bruno → Postman swap and Zed removal from [#8](https://github.com/vixygrey/vixygrey-dev-setup/pull/8)

Once this merges, tagging `v2.2.0` triggers `.github/workflows/release.yml` to build and publish the per-platform release zips.

## Test plan
- [ ] `./scripts/setup-dev-tools-mac.sh --version` prints `v2.2.0`
- [ ] `./scripts/setup-dev-tools-linux.sh --version` prints `v2.2.0`
- [ ] `./scripts/setup-dev-tools-windows.ps1 --version` prints `v2.2.0`
- [ ] CHANGELOG renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)