### PR TITLE
feat(tools): add ouch + harlequin; wire up pre-commit config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ What this PR does and why.
 
 ## Changes
 
-- 
+-
 
 ## Test Plan
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Pre-commit hooks for vixygrey-dev-setup
+# Install:  pre-commit install
+# Run all:  pre-commit run --all-files
+# Update:   pre-commit autoupdate
+
+repos:
+  # ShellCheck — mirrors CI (warning severity, follow sourced files)
+  # Uses shellcheck-py (pip-bundled binary) instead of the Docker-based
+  # koalaman/shellcheck-precommit so no container runtime is required.
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["-x", "-S", "warning"]
+        files: ^scripts/setup-dev-tools-(mac|linux)\.sh$
+
+  # Secret scanning — fast pre-commit pass before pushing
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  # Source spell checker — low false-positive rate, configurable via .typos.toml
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.27.3
+    hooks:
+      - id: typos
+
+  # File hygiene — restricted to text-config files to avoid touching the
+  # 7k-line setup scripts (which embed heredocs that may rely on exact bytes).
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        files: \.(md|yaml|yml|json|toml)$
+      - id: end-of-file-fixer
+        files: \.(md|yaml|yml|json|toml)$
+      - id: check-merge-conflict
+      - id: check-yaml
+        files: \.(yaml|yml)$
+      - id: check-added-large-files
+        args: ["--maxkb=500"]

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,12 @@
+# typos configuration — https://github.com/crate-ci/typos
+# Accept identifiers that typos' default dictionary flags incorrectly.
+
+[default.extend-identifiers]
+# Cask/package IDs for third-party apps we reference by their upstream name.
+iterm = "iterm"
+iterm2 = "iterm2"
+iTerm2 = "iTerm2"
+
+[default.extend-words]
+# Same, as whole-word fallback.
+iterm = "iterm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,4 +54,3 @@
 ### Refactoring
 
 - Remove tmux (replaced by zellij), replace Proton suite with Mullvad VPN
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,18 @@ pwsh -Command "Invoke-ScriptAnalyzer -Path scripts/setup-dev-tools-windows.ps1 -
 
 CI runs both ShellCheck and PSScriptAnalyzer automatically on every PR.
 
+### Pre-commit hooks (recommended)
+
+The repo ships a `.pre-commit-config.yaml` that runs ShellCheck (matching CI), gitleaks, typos, and a few file-hygiene checks before every commit. Install once:
+
+```bash
+pre-commit install                    # installs the git hook
+pre-commit run --all-files            # run all hooks against the whole repo
+pre-commit autoupdate                 # bump hook versions
+```
+
+`pre-commit` is installed by the setup scripts on all three platforms.
+
 ## Guidelines
 
 - **Keep scripts idempotent** -- every install block should skip if the tool is already present

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 | `watch` | **viddy** | Modern watch with diff highlighting and history |
 | `hexdump` | **hexyl** | Colorized hex viewer with ASCII sidebar |
 | `curl`/`wget` | **aria2** | Multi-connection parallel downloads, 3-10x faster, BitTorrent |
+| `tar`/`unzip`/`7z` | **ouch** | Universal archive tool -- auto-detects format from extension |
 | `rm` | **trash** | Moves files to macOS Trash instead of permanent delete |
 | `rsync` | **rsync** (latest) | Updated rsync with better progress and Apple metadata |
 | `tree` | **tree** | Directory listing in tree format |
@@ -326,6 +327,7 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 | **pgcli** | Auto-completing PostgreSQL CLI with syntax highlighting |
 | **mycli** | Auto-completing MySQL CLI with syntax highlighting |
 | **lazysql** | TUI for databases -- interactive SQL queries in terminal |
+| **harlequin** | Terminal SQL IDE -- multi-tab, autocomplete, DuckDB/Postgres/MySQL/S3 |
 | **usql** | Universal SQL CLI -- connects to Postgres, MySQL, SQLite, and more |
 | **sq** | jq for databases -- query SQLite, Postgres, CSV from one tool |
 | **dbmate** | Lightweight, framework-agnostic database migration tool |
@@ -553,6 +555,7 @@ Applied consistently across all tools:
 | **yazi** | Dracula file type colors and borders |
 | **btop** | Full Dracula theme with custom color palette |
 | **lazydocker** | Dracula borders and options colors |
+| **harlequin** | Dracula theme set in config.toml |
 | **vivid** | Dracula-themed LS_COLORS for file type coloring |
 | **vim** | Dracula-ish color scheme (no plugin needed) |
 | **VS Code brackets** | Dracula-colored bracket pair colorization |
@@ -810,6 +813,7 @@ The script generates config files with sensible defaults:
 | `~/.config/lazydocker/` | lazydocker | Dracula theme, timestamps, compose support |
 | `~/.config/pip/pip.conf` | pip | Require virtualenv, no telemetry |
 | `~/.config/pgcli/config` | pgcli | Multi-line, auto-expand, destructive warnings, bat pager |
+| `~/.config/harlequin/config.toml` | harlequin | Dracula theme, vscode keymap, file tree on |
 | `~/.config/gh/config.yml` | GitHub CLI | SSH protocol, VS Code editor, delta pager, aliases (co, pv, pc, pl, il, pm, rel) |
 | `~/.aws/config` | AWS CLI | Default region, json output, bat pager, auto-prompt, SSO template |
 | `~/.config/git/hooks/` | git | Global pre-commit hooks (debug statements, large files >5MB, conflict markers) |

--- a/docs/GUIDE-LINUX.md
+++ b/docs/GUIDE-LINUX.md
@@ -173,6 +173,7 @@ Every standard Unix tool has a faster, modern alternative:
 | `jx` | `fx` | Interactive JSON viewer |
 | `md` | `glow` | Render Markdown in terminal |
 | `wget` / `dl` | `aria2c` | Multi-connection downloader |
+| `tar` / `unzip` / `7z` | `ouch` | Universal archive tool -- auto-detects format |
 | `open` | `xdg-open` | Open files/URLs with default app |
 | `pbcopy` | `xclip -selection clipboard` | Copy to clipboard |
 | `pbpaste` | `xclip -selection clipboard -o` | Paste from clipboard |
@@ -492,6 +493,20 @@ lazysql                      # interactive database TUI
 # Browse tables, run queries, view results in a table
 ```
 
+### harlequin (terminal SQL IDE)
+
+Multi-tab SQL IDE with autocomplete, query history, and a results grid. Configured with the Dracula theme and vscode keymap at `~/.config/harlequin/config.toml`.
+
+```bash
+hq                           # alias for harlequin (opens last DB or DuckDB in-memory)
+harlequin                    # explicit
+harlequin file.duckdb        # open a DuckDB file
+harlequin -P 5432 -u postgres mydb     # connect to Postgres
+harlequin --adapter mysql -h localhost mydb   # connect to MySQL
+```
+
+Adapters bundled by the setup script: DuckDB (default), Postgres, MySQL, S3.
+
 ### sq (jq for databases)
 
 ```bash
@@ -707,7 +722,7 @@ oxipng -o 4 image.png        # lossless PNG compression
 jpegoptim --strip-all photo.jpg  # lossless JPEG compression
 
 # Batch compress
-fd -e png -x oxipng -o 4 {}  # compress all PNGs in project
+fd -e png -x oxipng -o 4 {}  # compress all ONGs in project
 
 # Resize / convert (ImageMagick)
 resize 800x600 image.png     # alias: resize image
@@ -1170,6 +1185,7 @@ Language-specific rules are in `~/.claude/rules/`:
 | `fmt-sh` | `shfmt -w -i 4` | Quality |
 | `update` | `topgrade` | System |
 | `sysinfo` | `fastfetch` | System |
+| `hq` | `harlequin` | Database |
 
 ### Directory Shortcuts
 

--- a/docs/GUIDE-MACOS.md
+++ b/docs/GUIDE-MACOS.md
@@ -147,6 +147,7 @@ Every standard Unix tool has a faster, modern alternative:
 | `jx` | `fx` | Interactive JSON viewer |
 | `md` | `glow` | Render Markdown in terminal |
 | `wget` / `dl` | `aria2c` | Multi-connection downloader |
+| `tar` / `unzip` / `7z` | `ouch` | Universal archive tool -- auto-detects format |
 
 ### Examples
 
@@ -421,6 +422,20 @@ lazysql                      # interactive database TUI
 # Browse tables, run queries, view results in a table
 ```
 
+### harlequin (terminal SQL IDE)
+
+Multi-tab SQL IDE with autocomplete, query history, and a results grid. Configured with the Dracula theme and vscode keymap at `~/.config/harlequin/config.toml`.
+
+```bash
+hq                           # alias for harlequin (opens last DB or DuckDB in-memory)
+harlequin                    # explicit
+harlequin file.duckdb        # open a DuckDB file
+harlequin -P 5432 -u postgres mydb     # connect to Postgres
+harlequin --adapter mysql -h localhost mydb   # connect to MySQL
+```
+
+Adapters bundled by the setup script: DuckDB (default), Postgres, MySQL, S3.
+
 ### sq (jq for databases)
 
 ```bash
@@ -634,7 +649,7 @@ oxipng -o 4 image.png        # lossless PNG compression
 jpegoptim --strip-all photo.jpg  # lossless JPEG compression
 
 # Batch compress
-fd -e png -x oxipng -o 4 {}  # compress all PNGs in project
+fd -e png -x oxipng -o 4 {}  # compress all ONGs in project
 
 # Resize / convert (ImageMagick)
 resize 800x600 image.png     # alias: resize image
@@ -1041,6 +1056,7 @@ Language-specific rules are in `~/.claude/rules/`:
 | `fmt-sh` | `shfmt -w -i 4` | Quality |
 | `update` | `topgrade` | System |
 | `sysinfo` | `fastfetch` | System |
+| `hq` | `harlequin` | Database |
 
 ### macOS-Specific Aliases
 

--- a/docs/GUIDE-WINDOWS.md
+++ b/docs/GUIDE-WINDOWS.md
@@ -231,6 +231,7 @@ Every standard tool has a faster, modern alternative:
 | `jx` | `fx` | Interactive JSON viewer |
 | `md` | `glow` | Render Markdown in terminal |
 | `dl` | `aria2c` | Multi-connection downloader |
+| `tar` / `unzip` / `7z` | `ouch` | Universal archive tool -- auto-detects format |
 
 > **Windows alias differences:** `ps`, `ping`, `dig`, and `watch` are PowerShell built-ins and cannot be overridden. Use `psg`, `ping2`, `dig2`, and `watch2` instead. Similarly, `pip` is aliased as `pip2` to avoid conflicts.
 
@@ -518,6 +519,20 @@ lazysql                      # interactive database TUI
 # Browse tables, run queries, view results in a table
 ```
 
+### harlequin (terminal SQL IDE)
+
+Multi-tab SQL IDE with autocomplete, query history, and a results grid. Configured with the Dracula theme and vscode keymap at `~/.config/harlequin/config.toml`.
+
+```powershell
+hq                           # alias for harlequin (opens last DB or DuckDB in-memory)
+harlequin                    # explicit
+harlequin file.duckdb        # open a DuckDB file
+harlequin -P 5432 -u postgres mydb     # connect to Postgres
+harlequin --adapter mysql -h localhost mydb   # connect to MySQL
+```
+
+Adapters bundled by the setup script: DuckDB (default), Postgres, MySQL, S3.
+
 ### sq (jq for databases)
 
 ```powershell
@@ -724,7 +739,7 @@ oxipng -o 4 image.png        # lossless PNG compression
 jpegoptim --strip-all photo.jpg  # lossless JPEG compression
 
 # Batch compress
-fd -e png -x oxipng -o 4 {}  # compress all PNGs in project
+fd -e png -x oxipng -o 4 {}  # compress all ONGs in project
 
 # Resize / convert (ImageMagick)
 magick input.png -resize 800x600 output.png   # resize image
@@ -1171,6 +1186,7 @@ Language-specific rules are in `~\.claude\rules\`:
 | `lint-sh` | `shellcheck` | Quality |
 | `update` | `topgrade` | System |
 | `sysinfo` | `fastfetch` | System |
+| `hq` | `harlequin` | Database |
 
 ### Directory Shortcuts
 

--- a/docs/SHORTCUTS-LINUX.md
+++ b/docs/SHORTCUTS-LINUX.md
@@ -48,6 +48,12 @@ Linux-specific alias differences from macOS:
 | `dl` | `aria2c` | Multi-connection downloader |
 | `wget` | `aria2c` | Download with 16 connections |
 
+### Database
+
+| Alias | Runs | What it does |
+|-------|------|-------------|
+| `hq` | `harlequin` | Terminal SQL IDE (DuckDB/Postgres/MySQL) |
+
 ### Git & GitHub
 
 | Alias | Runs | What it does |

--- a/docs/SHORTCUTS-MACOS.md
+++ b/docs/SHORTCUTS-MACOS.md
@@ -37,6 +37,12 @@ Quick reference for all **209+ shortcuts** configured by the setup scripts.
 | `dl` | `aria2c` | Multi-connection downloader |
 | `wget` | `aria2c` | Download with 16 connections |
 
+### Database
+
+| Alias | Runs | What it does |
+|-------|------|-------------|
+| `hq` | `harlequin` | Terminal SQL IDE (DuckDB/Postgres/MySQL) |
+
 ### Git & GitHub
 
 | Alias | Runs | What it does |

--- a/docs/SHORTCUTS-WINDOWS.md
+++ b/docs/SHORTCUTS-WINDOWS.md
@@ -39,6 +39,12 @@ Quick reference for all shortcuts and aliases configured by the setup scripts on
 | `dl` | `aria2c` | Multi-connection downloader |
 | `wget` | `aria2c` | Download with 16 connections |
 
+### Database
+
+| Alias | Runs | What it does |
+|-------|------|-------------|
+| `hq` | `harlequin` | Terminal SQL IDE (DuckDB/Postgres/MySQL) |
+
 ### Git & GitHub
 
 | Alias | Runs | What it does |

--- a/scripts/setup-dev-tools-linux.sh
+++ b/scripts/setup-dev-tools-linux.sh
@@ -223,7 +223,7 @@ list_categories() {
     printf "  %-25s %s\n" "dev-servers"         "ngrok, miniserve, caddy"
     printf "  %-25s %s\n" "terminal-productivity" "glow, watchexec, pv, parallel, gum, nushell, newsboat, topgrade, fastfetch, lnav, nnn, progress"
     printf "  %-25s %s\n" "k8s-github"          "stern, gh-dash"
-    printf "  %-25s %s\n" "database"            "pgcli, mycli, lazysql, usql, sq"
+    printf "  %-25s %s\n" "database"            "pgcli, mycli, lazysql, harlequin, usql, sq, DBeaver"
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
     printf "  %-25s %s\n" "api"                 "Postman, grpcurl"
     printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap, sshclick"
@@ -2053,6 +2053,17 @@ fi
 # aria2
 pkg_install "aria2" "aria2" "aria2" "aria2 (multi-connection downloads)"
 
+# tar/unzip/7z -> ouch: universal archive tool, auto-detects format
+if ! installed ouch; then
+    case "$PKG_MANAGER" in
+        pacman) pkg_install "-" "-" "ouch" "ouch (universal archive tool)" ;;
+        *) cargo_install "ouch" "ouch (universal archive tool — compress/decompress any format)" ;;
+    esac
+else
+    warn "ouch already installed"
+    progress
+fi
+
 # trash-cli (replaces rm)
 pip_install "trash-cli" "trash-cli (replaces rm — moves to Trash, recoverable)"
 
@@ -2433,6 +2444,27 @@ banner "Database & Data"
 pip_install "pgcli" "pgcli (auto-completing Postgres CLI)"
 pip_install "mycli" "mycli (auto-completing MySQL CLI)"
 cargo_install "lazysql" "lazysql (TUI for databases — interactive SQL in terminal)"
+
+# harlequin (terminal SQL IDE — DuckDB/Postgres/MySQL, multi-tab, autocomplete)
+if installed harlequin; then
+    warn "harlequin already installed"
+    progress
+elif installed uv; then
+    info "Installing harlequin via uv (with postgres,mysql,s3 adapters)..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        if uv tool install 'harlequin[postgres,mysql,s3]' >> "$LOG_FILE" 2>&1; then
+            success "harlequin installed (DuckDB + Postgres + MySQL + S3 adapters)"
+        else
+            error "Failed to install harlequin via uv"
+        fi
+    else
+        info "[DRY RUN] Would: uv tool install 'harlequin[postgres,mysql,s3]'"
+    fi
+    progress
+else
+    warn "Skipping harlequin — uv not installed"
+    progress
+fi
 
 # usql
 if installed go; then
@@ -5210,6 +5242,25 @@ PGCLI_CONF
     success "pgcli configured"
 fi
 
+# ---- harlequin config ----
+HARLEQUIN_CONFIG_DIR="$HOME/.config/harlequin"
+HARLEQUIN_CONFIG="$HARLEQUIN_CONFIG_DIR/config.toml"
+if [[ -f "$HARLEQUIN_CONFIG" ]]; then
+    warn "harlequin config already exists"
+else
+    info "Creating harlequin configuration..."
+    mkdir -p "$HARLEQUIN_CONFIG_DIR"
+    cat > "$HARLEQUIN_CONFIG" <<'HARLEQUIN_CONF'
+# Harlequin SQL IDE — https://harlequin.sql/docs/config-file/
+[defaults]
+theme = "dracula"
+keymap_name = ["vscode"]
+show_files = true
+locale = "en_US.UTF-8"
+HARLEQUIN_CONF
+    success "harlequin configured (Dracula theme, vscode keymap)"
+fi
+
 # ---- mycli config ----
 MYCLIRC="$HOME/.myclirc"
 if [[ -f "$MYCLIRC" ]]; then
@@ -7814,6 +7865,9 @@ alias fmt-sh=\"shfmt -w -i 4\"
 alias n=\"nnn -de\"
 alias prog=\"progress -m\"
 alias sshc=\"sshclick\"
+
+# Database
+alias hq=\"harlequin\"
 
 # Directory Shortcuts
 alias cw=\"z ~/Code/work\"

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -236,7 +236,7 @@ list_categories() {
     printf "  %-25s %s\n" "dev-servers"         "ngrok, miniserve, caddy"
     printf "  %-25s %s\n" "terminal-productivity" "glow, watchexec, pv, parallel, gum, nushell, topgrade, fastfetch, nnn, progress"
     printf "  %-25s %s\n" "k8s-github"          "stern, gh-dash"
-    printf "  %-25s %s\n" "database"            "pgcli, mycli, usql, sq, TablePlus"
+    printf "  %-25s %s\n" "database"            "pgcli, mycli, lazysql, harlequin, usql, sq, TablePlus"
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
     printf "  %-25s %s\n" "api"                 "Postman, grpcurl"
     printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap"
@@ -1158,6 +1158,9 @@ brew_install "hexyl" "hexyl (replaces hexdump — colorized hex viewer)"
 # curl/wget -> aria2: multi-connection parallel downloads, 3-10x faster
 brew_install "aria2" "aria2 (replaces curl/wget for downloads — multi-connection, BitTorrent)"
 
+# tar/unzip/7z -> ouch: universal archive tool, auto-detects format
+brew_install "ouch" "ouch (universal archive tool — compress/decompress any format)"
+
 # rm -> trash: moves to macOS Trash instead of permanent delete
 brew_install "trash" "trash (replaces rm — moves to macOS Trash, recoverable)"
 
@@ -1302,6 +1305,27 @@ banner "Database & Data"
 brew_install "pgcli" "pgcli (auto-completing Postgres CLI)"
 brew_install "mycli" "mycli (auto-completing MySQL CLI)"
 brew_install "lazysql" "lazysql (TUI for databases — interactive SQL in terminal)"
+
+# harlequin (terminal SQL IDE — DuckDB/Postgres/MySQL, multi-tab, autocomplete)
+if installed harlequin; then
+    warn "harlequin already installed"
+    progress
+elif installed uv; then
+    info "Installing harlequin via uv (with postgres,mysql,s3 adapters)..."
+    if [[ "$DRY_RUN" != "true" ]]; then
+        if uv tool install 'harlequin[postgres,mysql,s3]' >> "$LOG_FILE" 2>&1; then
+            success "harlequin installed (DuckDB + Postgres + MySQL + S3 adapters)"
+        else
+            error "Failed to install harlequin via uv"
+        fi
+    else
+        info "[DRY RUN] Would: uv tool install 'harlequin[postgres,mysql,s3]'"
+    fi
+    progress
+else
+    warn "Skipping harlequin — uv not installed"
+    progress
+fi
 # usql — not in Homebrew, install via Go
 progress
 if installed go; then
@@ -4427,6 +4451,25 @@ PGCLI_CONF
     success "pgcli configured (multi-line, auto-expand, destructive warnings, bat pager)"
 fi
 
+# ---- harlequin config ----
+HARLEQUIN_CONFIG_DIR="$HOME/.config/harlequin"
+HARLEQUIN_CONFIG="$HARLEQUIN_CONFIG_DIR/config.toml"
+if [[ -f "$HARLEQUIN_CONFIG" ]]; then
+    warn "harlequin config already exists"
+else
+    info "Creating harlequin configuration..."
+    mkdir -p "$HARLEQUIN_CONFIG_DIR"
+    cat > "$HARLEQUIN_CONFIG" <<'HARLEQUIN_CONF'
+# Harlequin SQL IDE — https://harlequin.sql/docs/config-file/
+[defaults]
+theme = "dracula"
+keymap_name = ["vscode"]
+show_files = true
+locale = "en_US.UTF-8"
+HARLEQUIN_CONF
+    success "harlequin configured (Dracula theme, vscode keymap)"
+fi
+
 # ---- mycli config ----
 MYCLIRC="$HOME/.myclirc"
 if [[ -f "$MYCLIRC" ]]; then
@@ -7088,6 +7131,9 @@ alias fmt-sh="shfmt -w -i 4"
 # -- Terminal Apps ------------------------------------------------------------
 alias n="nnn -de"
 alias prog="progress -m"
+
+# -- Database -----------------------------------------------------------------
+alias hq="harlequin"
 
 # -- Directory Shortcuts (using zoxide for smart jumping) --------------------
 alias cw="z ~/Code/work"

--- a/scripts/setup-dev-tools-windows.ps1
+++ b/scripts/setup-dev-tools-windows.ps1
@@ -233,7 +233,7 @@ function Show-Categories {
         @("dev-servers",           "ngrok, miniserve, caddy")
         @("terminal-productivity", "glow, watchexec, pv, parallel, topgrade, fastfetch, lnav")
         @("k8s-github",            "stern, gh-dash")
-        @("database",              "pgcli, mycli, usql, sq, DBeaver")
+        @("database",              "pgcli, mycli, lazysql, harlequin, usql, sq, DBeaver")
         @("containers",            "lazydocker, dive, kubectl, k9s")
         @("api",                   "Postman, grpcurl")
         @("networking",            "mtr/WinMTR, bandwhich, nmap")
@@ -932,6 +932,7 @@ Install-ScoopPackage "tree" "tree (directory listing)"
 Install-ScoopPackage "viddy" "viddy (replaces watch -- diff highlighting, history)"
 Install-ScoopPackage "hexyl" "hexyl (replaces hexdump -- colorized hex viewer)"
 Install-ScoopPackage "aria2" "aria2 (replaces curl/wget for downloads -- multi-connection, BitTorrent)"
+Install-ScoopPackage "ouch" "ouch (universal archive tool -- compress/decompress any format)"
 Install-ScoopPackage "difftastic" "difftastic (replaces diff for code -- syntax-aware structural diffs)"
 Install-ScoopPackage "vivid" "vivid (LS_COLORS generator -- colorize file listings by type)"
 Install-ScoopPackage "just" "just (replaces make -- simpler task runner, no tab issues)"
@@ -1072,6 +1073,25 @@ Write-Banner "Database & Data"
 Install-ScoopPackage "pgcli" "pgcli (auto-completing Postgres CLI)"
 Install-ScoopPackage "mycli" "mycli (auto-completing MySQL CLI)"
 Install-ScoopPackage "lazysql" "lazysql (TUI for databases -- interactive SQL in terminal)"
+
+# harlequin (terminal SQL IDE -- DuckDB/Postgres/MySQL, multi-tab, autocomplete)
+if (Test-Command "harlequin") {
+    Write-Warn "harlequin already installed"
+} elseif (Test-Command "uv") {
+    if (-not $DRY_RUN) {
+        Write-Info "Installing harlequin via uv (with postgres,mysql,s3 adapters)..."
+        uv tool install 'harlequin[postgres,mysql,s3]' 2>&1 | Out-File $LOG_FILE -Append
+        if (Test-Command "harlequin") {
+            Write-Success "harlequin installed (DuckDB + Postgres + MySQL + S3 adapters)"
+        } else {
+            Write-Error "Failed to install harlequin via uv"
+        }
+    } else {
+        Write-Info "[DRY RUN] Would: uv tool install 'harlequin[postgres,mysql,s3]'"
+    }
+} else {
+    Write-Warn "Skipping harlequin -- uv not installed"
+}
 
 # usql via go install
 if (Test-Command "go") {
@@ -3312,6 +3332,27 @@ keyword_casing = upper
 smart_completion = True
 "@
         Write-Success "pgcli configured (multi-line, auto-expand, destructive warnings)"
+    }
+}
+
+# ---- harlequin config ----
+$harlequinConfigDir = Join-Path $HOME ".config\harlequin"
+$harlequinConfig = Join-Path $harlequinConfigDir "config.toml"
+if (Test-Path $harlequinConfig) {
+    Write-Warn "harlequin config already exists"
+} else {
+    if (-not $DRY_RUN) {
+        Write-Info "Creating harlequin configuration..."
+        if (-not (Test-Path $harlequinConfigDir)) { New-Item -ItemType Directory -Path $harlequinConfigDir -Force | Out-Null }
+        Set-Content -Path $harlequinConfig -Value @"
+# Harlequin SQL IDE -- https://harlequin.sql/docs/config-file/
+[defaults]
+theme = "dracula"
+keymap_name = ["vscode"]
+show_files = true
+locale = "en_US.UTF-8"
+"@
+        Write-Success "harlequin configured (Dracula theme, vscode keymap)"
     }
 }
 
@@ -5909,6 +5950,7 @@ Set-Alias -Name lzd -Value lazydocker -Force -ErrorAction SilentlyContinue
 Set-Alias -Name k -Value kubectl -Force -ErrorAction SilentlyContinue
 Set-Alias -Name md -Value glow -Force -ErrorAction SilentlyContinue
 Set-Alias -Name y -Value yazi -Force -ErrorAction SilentlyContinue
+Set-Alias -Name hq -Value harlequin -Force -ErrorAction SilentlyContinue
 
 # Parameterized aliases as functions
 function ls { eza --icons @args }


### PR DESCRIPTION
## Summary

- Add **ouch** (universal archive tool) across all three platforms
- Add **harlequin** (terminal SQL IDE) across all three platforms, with Dracula/`vscode` config and `hq` alias
- Start consuming **pre-commit** in this repo (it was already installed by the setup scripts but had no config here)

Closes #10

## Changes

### New tools
- `scripts/setup-dev-tools-mac.sh`: `brew_install "ouch"` in modern-replacements; `uv tool install 'harlequin[postgres,mysql,s3]'` in database; `hq` zshrc alias; `~/.config/harlequin/config.toml` block
- `scripts/setup-dev-tools-linux.sh`: `cargo_install "ouch"` (pacman on Arch); same harlequin install + config + alias
- `scripts/setup-dev-tools-windows.ps1`: `Install-ScoopPackage "ouch"`; same harlequin install + config; `Set-Alias hq`
- Category summaries (`--list-categories`) updated on all three scripts

### Pre-commit
- `.pre-commit-config.yaml` with 8 hooks:
  - `shellcheck` via `shellcheck-py` (no Docker dependency; same `-x -S warning` flags as CI)
  - `gitleaks` (secret scanning)
  - `typos` (spell check)
  - `trailing-whitespace`, `end-of-file-fixer` (restricted to `md/yaml/yml/json/toml` to avoid touching script heredocs)
  - `check-merge-conflict`, `check-yaml`, `check-added-large-files`
- `.typos.toml` whitelists `iterm` / `iterm2` / `iTerm2` (third-party cask IDs flagged as typos)
- `CONTRIBUTING.md` now documents `pre-commit install` / `pre-commit run --all-files`

### Doc updates
- README: database table adds harlequin; modern-replacements table adds ouch; configuration files table adds `~/.config/harlequin/config.toml`; Dracula table adds harlequin
- `docs/GUIDE-{MACOS,LINUX,WINDOWS}.md`: harlequin usage block added, ouch row in the replacements table, `hq` row in the aliases table
- `docs/SHORTCUTS-{MACOS,LINUX,WINDOWS}.md`: new Database section with `hq`

### Drive-by hook fixes
- `.github/PULL_REQUEST_TEMPLATE.md`: trailing whitespace after a bullet
- `CHANGELOG.md`: removed a stray blank line at EOF

Net diff: +285 / -8 across 15 files.

## Test plan
- [x] `bash -n` passes on both shell scripts
- [x] `pre-commit run --all-files` passes (all 8 hooks green)
- [ ] On a fresh macOS: `./scripts/setup-dev-tools-mac.sh --only database,replacements` installs ouch + harlequin; `hq --version` and `ouch --version` work
- [ ] On fresh Linux: same via linux.sh
- [ ] On fresh Windows: same via windows.ps1; verify `harlequin` launches under Windows Terminal (Textual TUI)
- [ ] `harlequin file.duckdb` opens with Dracula theme applied from `~/.config/harlequin/config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)