### PR TITLE
chore(release): bump version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [Unreleased]
+## [3.0.0] - 2026-04-23
+
+**BREAKING:** Linux and Windows support removed. This is now a macOS-only project.
 
 ### Added
 
@@ -9,7 +11,7 @@
 
 ### Removed
 
-- **platforms**: Drop Linux and Windows support (#12). Deleted `scripts/setup-dev-tools-linux.sh`, `scripts/setup-dev-tools-windows.ps1`, and their per-platform `docs/GUIDE-*` / `docs/SHORTCUTS-*` files. Remaining macOS docs renamed to `docs/GUIDE.md` and `docs/SHORTCUTS.md`. CI workflows simplified to ShellCheck-only; release workflow now produces a single macOS zip.
+- **platforms**: Drop Linux and Windows support (#12, #13). Deleted `scripts/setup-dev-tools-linux.sh`, `scripts/setup-dev-tools-windows.ps1`, and their per-platform `docs/GUIDE-*` / `docs/SHORTCUTS-*` files. Remaining macOS docs renamed to `docs/GUIDE.md` and `docs/SHORTCUTS.md`. CI workflows simplified to ShellCheck-only; release workflow now produces a single macOS zip.
 
 ## [2.2.0] - 2026-04-23
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -3,14 +3,14 @@
 # =============================================================================
 # Development Environment Setup Script (macOS)
 # =============================================================================
-# Version:  2.2.0
+# Version:  3.0.0
 # Updated:  2026-04-05
 # Platform: macOS (Apple Silicon + Intel)
 # Run:      chmod +x setup-dev-tools.sh && ./setup-dev-tools.sh
 # Flags:    --dry-run, --list, --skip <cats>, --only <cats>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="2.2.0"
+SCRIPT_VERSION="3.0.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 


### PR DESCRIPTION
## Summary

- Bump `SCRIPT_VERSION` from `2.2.0` -> `3.0.0`
- Promote the `[Unreleased]` CHANGELOG block to `[3.0.0]` with a **BREAKING** notice covering the Linux/Windows removal from [#12](https://github.com/vixygrey/vixygrey-dev-setup/issues/12) / [#13](https://github.com/vixygrey/vixygrey-dev-setup/pull/13)

Once this merges, tagging `v3.0.0` triggers the release workflow to build and publish the macOS zip.

## Test plan
- [ ] `./scripts/setup-dev-tools-mac.sh --version` prints `v3.0.0`
- [ ] CHANGELOG renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)