### PR TITLE
feat(tools): add mas, dockutil, terminal-notifier and wire them in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **tools**: Add `mas` (Mac App Store CLI), `dockutil` (Dock management), and `terminal-notifier` (macOS notifications) to the `mac-system` category (#15)
+- **script**: Emit a macOS notification at end of run — success notification with install/skip/fail counts and duration, or failure notification with error log path if any step errored (uses `terminal-notifier`, no-op if not installed)
+
+### Changed
+
+- **Dock**: Replace the `defaults write persistent-apps -array` clearing block with a `dockutil` sequence that removes all defaults then pins a curated set (Finder, System Settings, VS Code, Ghostty, Raycast). Any app not present on disk is skipped with a warning, so partial installs still succeed. Falls back to the previous clear-only behavior if `dockutil` isn't installed (#15)
+
 ## [3.0.0] - 2026-04-23
 
 **BREAKING:** Linux and Windows support removed. This is now a macOS-only project.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ chmod +x scripts/setup-dev-tools-mac.sh
 4. Applies the **Dracula** theme everywhere
 5. Sets macOS system defaults (Dock, keyboard, Finder, screenshots, wallpaper, screensaver, etc.)
 6. Configures Finder sidebar with custom favorites via **LSSharedFileList** API
-7. Clears Dock of default pins (start fresh, drag your own)
+7. Curates the Dock via `dockutil` -- pins Finder, System Settings, VS Code, Ghostty, Raycast (skips any missing app)
 8. Optionally **removes pre-installed Apple bloat** (GarageBand, News, Stocks, etc.)
 9. Auto-writes `~/.zshrc` with a managed block (preserves your customizations)
 10. Exports a `Brewfile` snapshot (with descriptions) for reproducibility
@@ -416,6 +416,9 @@ Preview files in Finder by pressing spacebar.
 | **UniFi Identity Endpoint** | Wi-Fi, VPN, and device management for UniFi NAS |
 | **LuLu** | Free open-source outbound firewall -- see what phones home |
 | **Mullvad VPN** | Privacy-focused VPN -- no account required, anonymous payment accepted |
+| **mas** | Mac App Store CLI -- script MAS installs and updates |
+| **dockutil** | Manage Dock pins programmatically (used by the setup script to curate the Dock) |
+| **terminal-notifier** | Send macOS notifications from shell scripts (used by the setup script for run-complete/failure alerts) |
 
 ---
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -952,6 +952,54 @@ Installed automatically by the setup script via Homebrew Cask.
 
 ---
 
+## macOS Scripting Helpers
+
+The setup script installs three CLI tools that it also consumes itself. They're equally useful for your own shell scripts.
+
+### mas (Mac App Store CLI)
+
+Install and update MAS apps from the command line — useful for dotfiles, CI, and onboarding scripts.
+
+```bash
+mas signin you@example.com           # sign in once (prompts for password)
+mas list                             # show installed MAS apps
+mas search xcode                     # find apps by name
+mas install 497799835                # install Xcode by ID
+mas upgrade                          # upgrade all outdated MAS apps
+```
+
+The setup script does not install any MAS apps by default — `mas` is provided so your own scripts can.
+
+### dockutil (Dock management)
+
+Programmatically add, remove, and reorder Dock items. Used by the setup script to pin Finder, System Settings, VS Code, Ghostty, and Raycast.
+
+```bash
+dockutil --list                                      # show current Dock contents
+dockutil --add /Applications/VS\ Code.app            # pin an app
+dockutil --remove "VS Code"                          # unpin by label
+dockutil --move "VS Code" --after "Finder"           # reorder
+dockutil --remove all --no-restart && killall Dock   # reset the Dock
+```
+
+### terminal-notifier (macOS notifications)
+
+Send native macOS notifications from shell scripts. The setup script uses it for run-complete and failure alerts.
+
+```bash
+terminal-notifier -title "Build" -message "Finished in 42s" -sound Glass
+terminal-notifier -title "Deploy" -subtitle "prod" -message "Succeeded" -group my-pipeline
+terminal-notifier -title "Error" -message "Tests failed" -sound Basso
+```
+
+Useful for long-running local commands:
+
+```bash
+npm run build && terminal-notifier -title "Build" -message "Done" -sound Glass
+```
+
+---
+
 ## Claude Code
 
 ### Custom Slash Commands
@@ -1132,9 +1180,15 @@ The setup script configures these macOS defaults automatically via `defaults wri
 - Small icon size (36px), no recent apps shown
 - Scale minimize effect (faster than genie)
 - Minimize windows into application icon
-- Clears all default pinned apps (add your own by dragging)
+- **Curated pins via `dockutil`:** Finder, System Settings, VS Code, Ghostty, Raycast (any app not yet installed is skipped with a warning so partial installs still succeed)
 - Mission Control: fixed Spaces order, fast animations, grouped by app
 - Hot corners: all disabled to prevent accidental triggers
+
+To re-run just the Dock curation:
+
+```bash
+./scripts/setup-dev-tools-mac.sh --only macos-defaults
+```
 
 ### Screenshots
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -73,6 +73,19 @@ banner() {
     log "=== $title ==="
 }
 
+# macOS notification helpers — silently no-op if terminal-notifier isn't installed yet
+notify_success() {
+    local message="$1"
+    command -v terminal-notifier >/dev/null 2>&1 || return 0
+    terminal-notifier -title "Dev Setup" -subtitle "Completed" -message "$message" -sound Glass -group vixygrey-dev-setup >/dev/null 2>&1 || true
+}
+
+notify_failure() {
+    local message="$1"
+    command -v terminal-notifier >/dev/null 2>&1 || return 0
+    terminal-notifier -title "Dev Setup" -subtitle "Failed" -message "$message" -sound Basso -group vixygrey-dev-setup >/dev/null 2>&1 || true
+}
+
 # -- Counters -----------------------------------------------------------------
 INSTALL_SUCCESS=0
 INSTALL_SKIPPED=0
@@ -243,7 +256,7 @@ list_categories() {
     printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, VS Code, Ghostty, zellij, Raycast"
     printf "  %-25s %s\n" "ux"                  "Lighthouse"
     printf "  %-25s %s\n" "docs"                "d2, Mermaid CLI"
-    printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins"
+    printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins, mas, dockutil, terminal-notifier"
     printf "  %-25s %s\n" "mac-productivity"    "Notion, Skim, Transmit"
     printf "  %-25s %s\n" "mac-communication"   "Slack, Telegram"
     printf "  %-25s %s\n" "mac-browsers"        "Firefox, Brave, Carbonyl, w3m, monolith"
@@ -1486,6 +1499,11 @@ brew_cask_install "mullvadvpn" "Mullvad VPN (privacy-focused, no account email r
 
 # Utilities
 brew_cask_install "pearcleaner" "Pearcleaner (open-source deep app uninstaller)"
+
+# macOS scripting helpers — used by this script (Dock, notifications, MAS apps)
+brew_install "mas" "mas (Mac App Store CLI — install/update MAS apps from a script)"
+brew_install "dockutil" "dockutil (manage Dock pins programmatically)"
+brew_install "terminal-notifier" "terminal-notifier (send macOS notifications from shell scripts)"
 
 # Quick Look plugins (preview files in Finder with spacebar)
 brew_cask_install "qlmarkdown" "QLMarkdown (preview Markdown in Finder)"
@@ -3528,14 +3546,37 @@ sudo pmset -c displaysleep 120 2>/dev/null || true  # charger: 2 hours
 sudo pmset -b displaysleep 75 2>/dev/null || true   # battery: 1hr 15min
 success "Screensaver at 45min, display sleep at 2hr (charger) / 1h15m (battery)"
 
-# -- Clear Dock (remove all default pinned apps so user can set their own) --
+# -- Dock: clear defaults and pin a curated set via dockutil --
+# Pinned apps (in order): Finder, System Settings, VS Code, Ghostty, Raycast.
+# Only pins an app if it exists on disk — survives a partial install.
 if [[ "$DRY_RUN" != "true" ]]; then
-    info "Clearing all default apps from Dock (pin your own via drag-and-drop)..."
-    defaults write com.apple.dock persistent-apps -array
-    defaults write com.apple.dock persistent-others -array
-    success "Dock cleared — drag apps to Dock to pin them"
+    if command -v dockutil >/dev/null 2>&1; then
+        info "Configuring Dock with curated pins via dockutil..."
+        dockutil --remove all --no-restart >/dev/null 2>&1 || true
+
+        dock_pins=(
+            "/System/Library/CoreServices/Finder.app"
+            "/System/Applications/System Settings.app"
+            "/Applications/Visual Studio Code.app"
+            "/Applications/Ghostty.app"
+            "/Applications/Raycast.app"
+        )
+        for app in "${dock_pins[@]}"; do
+            if [[ -d "$app" ]]; then
+                dockutil --add "$app" --no-restart >/dev/null 2>&1 || warn "dockutil: failed to pin $(basename "$app" .app)"
+            else
+                warn "Dock: skipping $(basename "$app" .app) — not installed"
+            fi
+        done
+        success "Dock configured (Finder, System Settings, VS Code, Ghostty, Raycast)"
+    else
+        # Fallback if dockutil didn't install: clear the Dock the old way
+        warn "dockutil not installed — clearing Dock via defaults instead"
+        defaults write com.apple.dock persistent-apps -array
+        defaults write com.apple.dock persistent-others -array
+    fi
 else
-    info "[DRY RUN] Would clear all default apps from Dock"
+    info "[DRY RUN] Would pin Finder, System Settings, VS Code, Ghostty, Raycast to Dock via dockutil"
 fi
 
 # Restart Dock to apply all Dock/Hot Corner/Mission Control changes
@@ -7496,6 +7537,13 @@ if [[ "$DRY_RUN" == "true" ]]; then
     echo -e "${YELLOW}${BOLD}  This was a dry run — no changes were made.${NC}"
     echo -e "${YELLOW}  Run without --dry-run to install everything.${NC}"
     echo ""
+else
+    # macOS notification: success or failure summary
+    if [[ ${#FAILED_ITEMS[@]} -gt 0 ]]; then
+        notify_failure "${INSTALL_FAILED} item(s) failed — see $ERROR_LOG"
+    else
+        notify_success "Installed $INSTALL_SUCCESS, skipped $INSTALL_SKIPPED in ${MINUTES}m ${SECONDS_REMAINING}s"
+    fi
 fi
 
 if [[ "$DRY_RUN" == "false" ]]; then


### PR DESCRIPTION
## Summary

Adds three macOS-native CLI tools to the \`mac-system\` category and consumes them inside the setup script itself for nicer Dock management and end-of-run notifications.

Closes #15

## Changes

### New tools (\`brew install\` in mac-system)
- **\`mas\`** -- Mac App Store CLI. Install only; no MAS apps are scripted by default (per your call).
- **\`dockutil\`** -- Dock pin management.
- **\`terminal-notifier\`** -- Send macOS notifications from shell scripts.

### Script behavior

**Dock curation** (replaces the old \`defaults write persistent-apps -array\` block):
1. \`dockutil --remove all --no-restart\`
2. Pin in order: Finder, System Settings, VS Code, Ghostty, Raycast
3. Skip any app not present on disk (so a partial install still succeeds)
4. \`killall Dock\` once at the end
5. Falls back to the old clear-only behavior if \`dockutil\` isn't installed (e.g., \`--skip mac-system\`)

**Notifications** (new \`notify_success\` / \`notify_failure\` helpers):
- On successful run: \`terminal-notifier -title \"Dev Setup\" -subtitle \"Completed\" -message \"Installed N, skipped M in Xm Ys\" -sound Glass\`
- On any step failure: \`terminal-notifier -title \"Dev Setup\" -subtitle \"Failed\" -message \"N item(s) failed — see <error-log>\" -sound Basso\`
- Both helpers silently no-op if \`terminal-notifier\` isn't installed yet
- Skipped entirely on \`--dry-run\`
- Grouped by \`vixygrey-dev-setup\` so successive runs replace the previous notification instead of stacking

### Docs
- README: new rows under **Mac Apps -- System & Utilities**; updated the Dock bullet in **What It Does**
- \`docs/GUIDE.md\`: updated the **Dock** section to reflect the curated pins; new **macOS Scripting Helpers** section with usage examples for all three tools
- \`CHANGELOG.md\`: \`[Unreleased]\` entries

## Test plan
- [x] \`bash -n scripts/setup-dev-tools-mac.sh\` passes
- [x] \`pre-commit run --all-files\` passes
- [ ] On a fresh macOS: \`./scripts/setup-dev-tools-mac.sh --only mac-system\` installs all three tools
- [ ] \`./scripts/setup-dev-tools-mac.sh --only macos-defaults\` produces a Dock with exactly 5 pins (Finder, System Settings, VS Code, Ghostty, Raycast), skipping any app not installed
- [ ] Full run ending in success triggers a macOS notification (Glass sound)
- [ ] Inject a fake failure (e.g., \`brew_install \"nonexistent-cask\"\`) -- confirm failure notification fires with Basso sound
- [ ] \`--dry-run\` suppresses both notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)