### PR TITLE
chore(release): bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## [Unreleased]
+## [3.1.0] - 2026-04-23
 
 ### Added
 
-- **tools**: Add `mas` (Mac App Store CLI), `dockutil` (Dock management), and `terminal-notifier` (macOS notifications) to the `mac-system` category (#15)
+- **tools**: Add `mas` (Mac App Store CLI), `dockutil` (Dock management), and `terminal-notifier` (macOS notifications) to the `mac-system` category (#15, #16)
 - **script**: Emit a macOS notification at end of run — success notification with install/skip/fail counts and duration, or failure notification with error log path if any step errored (uses `terminal-notifier`, no-op if not installed)
 
 ### Changed
 
-- **Dock**: Replace the `defaults write persistent-apps -array` clearing block with a `dockutil` sequence that removes all defaults then pins a curated set (Finder, System Settings, VS Code, Ghostty, Raycast). Any app not present on disk is skipped with a warning, so partial installs still succeed. Falls back to the previous clear-only behavior if `dockutil` isn't installed (#15)
+- **Dock**: Replace the `defaults write persistent-apps -array` clearing block with a `dockutil` sequence that removes all defaults then pins a curated set (Finder, System Settings, VS Code, Ghostty, Raycast). Any app not present on disk is skipped with a warning, so partial installs still succeed. Falls back to the previous clear-only behavior if `dockutil` isn't installed (#15, #16)
 
 ## [3.0.0] - 2026-04-23
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -3,14 +3,14 @@
 # =============================================================================
 # Development Environment Setup Script (macOS)
 # =============================================================================
-# Version:  3.0.0
+# Version:  3.1.0
 # Updated:  2026-04-05
 # Platform: macOS (Apple Silicon + Intel)
 # Run:      chmod +x setup-dev-tools.sh && ./setup-dev-tools.sh
 # Flags:    --dry-run, --list, --skip <cats>, --only <cats>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="3.0.0"
+SCRIPT_VERSION="3.1.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 


### PR DESCRIPTION
## Summary
- Bump \`SCRIPT_VERSION\` from \`3.0.0\` -> \`3.1.0\`
- Promote the \`[Unreleased]\` CHANGELOG block to \`[3.1.0]\` covering the mas/dockutil/terminal-notifier work from [#16](https://github.com/vixygrey/vixygrey-dev-setup/pull/16)

Minor bump: additive features (three new tools, Dock curation, end-of-run notifications), no breaking changes.

Once this merges, tagging \`v3.1.0\` triggers the release workflow to build and publish the macOS zip.

## Test plan
- [ ] \`./scripts/setup-dev-tools-mac.sh --version\` prints \`v3.1.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)