### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run ShellCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract version from tag
         id: version
@@ -30,7 +30,7 @@ jobs:
           cd build/macos && zip -r "../../vixygrey-dev-setup-macos-${VERSION}.zip" . && cd ../..
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## Summary

GitHub is forcing all actions to Node 24 by default on **2026-06-02**, and removing the Node 20 runtime entirely on **2026-09-16**. Bumping the two Node-based actions we use to their latest majors (both already run on Node 24) to remove the deprecation warnings that have been appearing on every release run.

## Changes

- \`actions/checkout@v4\` -> \`actions/checkout@v6\` (latest: [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2), 2026-01-09) — in both \`lint.yml\` and \`release.yml\`
- \`softprops/action-gh-release@v2\` -> \`softprops/action-gh-release@v3\` (latest: [v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0), 2026-04-12) — in \`release.yml\`

## Test plan
- [ ] Lint workflow runs clean on this PR (ShellCheck)
- [ ] No \"Node.js 20 actions are deprecated\" warnings in the run annotations
- [ ] Next tag push (future release) runs the release workflow without deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)