### PR TITLE
chore(dock): drop curated pin list and enable auto-hide

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1177,18 +1177,14 @@ The setup script configures these macOS defaults automatically via `defaults wri
 
 ### Dock
 
+- Auto-hide enabled
 - Small icon size (36px), no recent apps shown
 - Scale minimize effect (faster than genie)
 - Minimize windows into application icon
-- **Curated pins via `dockutil`:** Finder, System Settings, VS Code, Ghostty, Raycast (any app not yet installed is skipped with a warning so partial installs still succeed)
 - Mission Control: fixed Spaces order, fast animations, grouped by app
 - Hot corners: all disabled to prevent accidental triggers
 
-To re-run just the Dock curation:
-
-```bash
-./scripts/setup-dev-tools-mac.sh --only macos-defaults
-```
+`dockutil` is still installed for manual Dock management — see the dockutil section above.
 
 ### Screenshots
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -3420,8 +3420,7 @@ if [[ "$DRY_RUN" != "true" ]]; then
 
 # -- Dock --
 # Auto-hide the Dock
-# Keep Dock visible but small
-defaults write com.apple.dock autohide -bool false
+defaults write com.apple.dock autohide -bool true
 # Small Dock icon size
 defaults write com.apple.dock tilesize -integer 36
 # Don't show recent applications
@@ -3545,39 +3544,6 @@ defaults -currentHost write com.apple.screensaver idleTime -int 2700 2>/dev/null
 sudo pmset -c displaysleep 120 2>/dev/null || true  # charger: 2 hours
 sudo pmset -b displaysleep 75 2>/dev/null || true   # battery: 1hr 15min
 success "Screensaver at 45min, display sleep at 2hr (charger) / 1h15m (battery)"
-
-# -- Dock: clear defaults and pin a curated set via dockutil --
-# Pinned apps (in order): Finder, System Settings, VS Code, Ghostty, Raycast.
-# Only pins an app if it exists on disk — survives a partial install.
-if [[ "$DRY_RUN" != "true" ]]; then
-    if command -v dockutil >/dev/null 2>&1; then
-        info "Configuring Dock with curated pins via dockutil..."
-        dockutil --remove all --no-restart >/dev/null 2>&1 || true
-
-        dock_pins=(
-            "/System/Library/CoreServices/Finder.app"
-            "/System/Applications/System Settings.app"
-            "/Applications/Visual Studio Code.app"
-            "/Applications/Ghostty.app"
-            "/Applications/Raycast.app"
-        )
-        for app in "${dock_pins[@]}"; do
-            if [[ -d "$app" ]]; then
-                dockutil --add "$app" --no-restart >/dev/null 2>&1 || warn "dockutil: failed to pin $(basename "$app" .app)"
-            else
-                warn "Dock: skipping $(basename "$app" .app) — not installed"
-            fi
-        done
-        success "Dock configured (Finder, System Settings, VS Code, Ghostty, Raycast)"
-    else
-        # Fallback if dockutil didn't install: clear the Dock the old way
-        warn "dockutil not installed — clearing Dock via defaults instead"
-        defaults write com.apple.dock persistent-apps -array
-        defaults write com.apple.dock persistent-others -array
-    fi
-else
-    info "[DRY RUN] Would pin Finder, System Settings, VS Code, Ghostty, Raycast to Dock via dockutil"
-fi
 
 # Restart Dock to apply all Dock/Hot Corner/Mission Control changes
 killall Dock 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Stop pinning a curated app list (Finder, System Settings, VS Code, Ghostty, Raycast) to the Dock — Dock contents are personal preference.
- Enable Dock auto-hide by default (`com.apple.dock autohide = true`).
- `dockutil` is still installed for manual Dock management.

## Changes

- `scripts/setup-dev-tools-mac.sh`: flip `autohide` to `true`; remove the `dockutil` curated-pins block (and its dry-run / `defaults write persistent-apps -array` fallback branches).
- `docs/GUIDE.md`: drop the "Curated pins via `dockutil`" bullet and the "re-run Dock curation" snippet; add an auto-hide bullet.

## Test plan

- [ ] `bash -n scripts/setup-dev-tools-mac.sh` passes
- [ ] Run `./scripts/setup-dev-tools-mac.sh --only macos-defaults` on a clean macOS user — confirm Dock auto-hides and existing user pins are not touched
- [ ] `--dry-run` no longer logs the "Would pin Finder, System Settings, …" line

Closes #19