### PR TITLE
chore(ci): add main branch protection ruleset spec

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,48 @@
+# Branch protection rulesets
+
+Version-controlled GitHub repository rulesets for this repo. Each `*.json`
+file in this directory is a ruleset spec that can be applied via the GitHub
+REST API.
+
+## Files
+
+- [`main.json`](main.json) — protections for the default branch (`main`):
+  - Require pull request before merging (squash-merge only, conversation
+    resolution required, stale reviews dismissed on new push)
+  - Require `ShellCheck` status check to pass, with the branch up to date
+  - Block force pushes (`non_fast_forward`) and branch deletion
+  - Require linear history (matches the `gh pm` squash-merge workflow)
+  - Repo admins bypass the ruleset (for emergency fixes)
+
+Required approving reviews and signed commits are intentionally **not** set
+— this is a single-maintainer repo and requiring reviews would self-block.
+Add them later if collaborators come on board.
+
+## Apply a ruleset
+
+Create or update the `main` ruleset on the live repo:
+
+```bash
+# Create (first time)
+gh api repos/:owner/:repo/rulesets \
+  --method POST \
+  --input .github/rulesets/main.json
+
+# Update (subsequent edits — replace <ID> with the ruleset id)
+gh api repos/:owner/:repo/rulesets/<ID> \
+  --method PUT \
+  --input .github/rulesets/main.json
+```
+
+List existing rulesets to find the id:
+
+```bash
+gh api repos/:owner/:repo/rulesets
+```
+
+## Editing
+
+Edit the JSON, commit on a feature branch, open a PR, and re-apply with
+the `PUT` command above after merge. Keep the file as the source of truth
+— if the live ruleset drifts (edited via GitHub's UI), re-apply from JSON
+to bring it back in line.

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,43 @@
+{
+  "name": "main branch protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "ShellCheck" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Version-control the GitHub repository ruleset that protects `main`.
- Already applied to the live repo (id `15727889`); this PR captures the spec and apply/update instructions.

## What the ruleset enforces on `main`

- PR required before merging — squash merge only
- `ShellCheck` status check must pass; branch must be up to date with `main`
- Conversation resolution required
- Stale approvals dismissed on new commits
- Force pushes (`non_fast_forward`) blocked
- Branch deletion blocked
- Linear history required
- Repo admin bypass (emergency hotfixes)

## Intentionally skipped

- Required approving reviews — single-maintainer repo, would self-block
- Required signed commits — adds friction for now

## Files

- `.github/rulesets/main.json` — ruleset spec (source of truth)
- `.github/rulesets/README.md` — apply via `gh api repos/:owner/:repo/rulesets`

## Test plan

- [x] `jq` validates `main.json`
- [x] `gh api repos/vixygrey/vixygrey-dev-setup/rulesets POST --input main.json` returned 201 with the rules echoed back
- [ ] CI's existing ShellCheck job runs on this PR and passes (no script changes, but the workflow still triggers on PR)
- [ ] After merge: try `git push origin main` directly → expect rejection by the ruleset

Closes #21