### PR TITLE
chore(release): bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.2.0] - 2026-04-29
+
+### Changed
+
+- **Dock**: Stop pinning a curated app list (Finder, System Settings, VS Code, Ghostty, Raycast) on setup — Dock contents are personal preference. Enable Dock auto-hide by default (`com.apple.dock autohide = true`). `dockutil` is still installed for manual Dock management (#20)
+- **ci**: Bump GitHub Actions runtimes to Node 24 (#18)
+
+### Added
+
+- **repo**: Version-controlled GitHub repository ruleset for `main` at `.github/rulesets/main.json` (PR-only, squash-merge, ShellCheck required, force pushes / branch deletion blocked, linear history, admin bypass) plus apply/update instructions in `.github/rulesets/README.md`. Already applied live (#22)
+
 ## [3.1.0] - 2026-04-23
 
 ### Added

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -10,7 +10,7 @@
 # Flags:    --dry-run, --list, --skip <cats>, --only <cats>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="3.1.0"
+SCRIPT_VERSION="3.2.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 


### PR DESCRIPTION
## Summary

Cuts the v3.2.0 release. Bumps `SCRIPT_VERSION` and adds the CHANGELOG entry covering everything that landed since v3.1.0.

## Included

- **Dock**: drop curated pin list, enable auto-hide by default ([#20](https://github.com/vixygrey/vixygrey-dev-setup/pull/20))
- **ci**: bump GitHub Actions runtimes to Node 24 ([#18](https://github.com/vixygrey/vixygrey-dev-setup/pull/18))
- **repo**: version-controlled `main` branch protection ruleset ([#22](https://github.com/vixygrey/vixygrey-dev-setup/pull/22))

## Versioning

Going minor (3.1.0 → 3.2.0) — the dock change is a user-visible default behavior change, consistent with how 2.2.0 was bumped for "Changed" entries.

## Test plan

- [x] `bash -n scripts/setup-dev-tools-mac.sh` passes
- [x] `./scripts/setup-dev-tools-mac.sh --version` shows `v3.2.0` after merge
- [ ] After merge: tag `v3.2.0` on `main` → release workflow builds the macOS zip