### PR TITLE
feat: dx toolbox additions, IaC tooling, state file truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ chmod +x scripts/setup-dev-tools-mac.sh
 |------|-------------|
 | **OpenTofu** | Open-source Terraform alternative -- multi-cloud infrastructure as code |
 | **tflint** | Terraform/OpenTofu linter -- catches errors before apply |
+| **terraform-docs** | Auto-generate module README sections from variables and outputs |
+| **checkov** | IaC static analysis -- Terraform, CloudFormation, Kubernetes, Dockerfile |
 | **infracost** | Cost estimation for Terraform changes before apply |
+| _tfsec_ | _Folded into `trivy config` -- not installed separately_ |
 
 ---
 
@@ -353,8 +356,11 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 | **atuin** | Replaces shell history with SQLite-backed, fuzzy-searchable database |
 | **mise** | Universal version manager -- Node, Python, Go, Ruby all in one (replaces nvm + pyenv + rbenv) |
 | **Kiro** | Primary code editor and IDE — VS Code fork with built-in Claude agent (specs, steering, hooks, MCP) |
-| **Claude Code** | AI-assisted coding in the terminal |
+| **Claude Code** | AI-assisted coding in the terminal (Anthropic, agentic) |
 | **GitHub Copilot CLI** | AI suggestions in the terminal (via `gh copilot suggest`) |
+| **aider** | Terminal AI pair programmer -- git-aware edit loops, complementary to Claude Code |
+| **llm** | Simon Willison's CLI -- one-shot prompts, plugin ecosystem, SQLite logging, embeddings |
+| **repomix** | Pack a repo into a single LLM-friendly file with token counts -- great for bootstrapping any agent |
 | **chezmoi** | Dotfile manager -- backup and restore configs across machines |
 | **mitmproxy** | Free HTTP debugging proxy -- inspect and modify API calls from any app |
 | **Ghostty** | Fast GPU-accelerated terminal -- daily driver, native macOS feel |
@@ -593,7 +599,7 @@ The script sets up Claude Code with a comprehensive configuration for full-stack
 Common safe commands are pre-approved so Claude doesn't ask every time:
 - **Package managers**: npm, pnpm, bun, npx, uv, cargo, pip
 - **Git**: all git and gh commands
-- **AWS & IaC**: aws, cdk, sam, tofu, tflint, infracost
+- **AWS & IaC**: aws, cdk, sam, tofu, tflint, terraform-docs, checkov, infracost
 - **Docker & K8s**: docker, docker-compose, kubectl, k9s, stern
 - **Build tools**: make, just, tsc, jest, vitest
 - **File tools**: cat, bat, ls, eza, find, grep, rg, fd, fzf, tree, jq, yq, fx, mlr, csvlook

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -240,7 +240,7 @@ list_categories() {
     printf "  %-25s %s\n" "core"                "mise (Node, Python), Go, Rust, OrbStack, bun, uv, pnpm"
     printf "  %-25s %s\n" "git"                 "Git, GitHub CLI, delta, lazygit, pre-commit"
     printf "  %-25s %s\n" "aws"                 "AWS CLI, CDK, SAM, Granted, cfn-lint"
-    printf "  %-25s %s\n" "iac"                 "OpenTofu (Terraform), tflint, infracost"
+    printf "  %-25s %s\n" "iac"                 "OpenTofu (Terraform), tflint, terraform-docs, checkov, infracost"
     printf "  %-25s %s\n" "security"            "detect-secrets, gitleaks, trivy, semgrep, Snyk, ClamAV, Objective-See"
     printf "  %-25s %s\n" "replacements"        "eza, bat, fd, ripgrep, zoxide, btop, sd, dust, just, yazi, fx, etc."
     printf "  %-25s %s\n" "data-processing"     "yq, miller, csvkit, pandoc, ffmpeg, ImageMagick"
@@ -253,7 +253,7 @@ list_categories() {
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
     printf "  %-25s %s\n" "api"                 "Postman, grpcurl"
     printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap"
-    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, Kiro, Ghostty, zellij, Raycast"
+    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, Kiro, Ghostty, zellij, Raycast, aider, llm, repomix"
     printf "  %-25s %s\n" "ux"                  "Lighthouse"
     printf "  %-25s %s\n" "docs"                "d2, Mermaid CLI"
     printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins, mas, dockutil, terminal-notifier"
@@ -1038,7 +1038,11 @@ banner "Infrastructure as Code"
 
 brew_install "opentofu" "OpenTofu (open-source Terraform — multi-cloud IaC)"
 brew_install "tflint" "tflint (Terraform linter)"
+brew_install "terraform-docs" "terraform-docs (auto-generate module docs from variables/outputs)"
+brew_install "checkov" "checkov (IaC static analysis — Terraform, CloudFormation, Kubernetes, Dockerfile)"
 brew_install "infracost" "infracost (cost estimation for Terraform changes before apply)"
+# Note: tfsec was folded into trivy (installed under 'security'). Run `trivy config .`
+# instead — same Terraform misconfig coverage, broader scan surface.
 
 fi  # iac
 
@@ -1451,6 +1455,13 @@ if installed gh; then
             error "Failed to install GitHub Copilot CLI extension"
         fi
     fi
+fi
+
+# Additional agentic / LLM CLIs that pair with Claude Code + Kiro
+brew_install "aider" "aider (terminal AI pair programmer — git-aware edit loops)"
+brew_install "llm" "llm (Simon Willison's CLI — one-shot prompts, plugins, SQLite logs, embeddings)"
+if installed npm; then
+    npm_global_install "repomix" "repomix (pack a repo into a single LLM-friendly file with token counts)"
 fi
 
 # Productivity apps
@@ -6102,6 +6113,8 @@ else
       "Bash(act *)",
       "Bash(tofu *)",
       "Bash(tflint *)",
+      "Bash(terraform-docs *)",
+      "Bash(checkov *)",
       "Bash(infracost *)",
       "Bash(trivy *)",
       "Bash(semgrep *)",
@@ -6250,7 +6263,8 @@ else
 - **Testing**: `hyperfine` to benchmark, `oha` for load testing, `hurl` for HTTP test files, `act` for local GitHub Actions
 - **Code quality**: `typos` for spell checking, `ast-grep` for structural search/replace, `shellcheck`/`shfmt` for shell
 - **Security**: `trivy` to scan containers/IaC, `gitleaks` for secrets, `semgrep` for static analysis, `snyk` for dependency scanning, `detect-secrets` for pre-commit secret detection, `sops` for secrets encryption
-- **IaC**: `tofu` (Terraform), `tflint` for linting, `infracost` for cost estimation, `cfn-lint` for CloudFormation, `aws-sam-cli` for SAM
+- **IaC**: `tofu` (Terraform), `tflint` for linting, `terraform-docs` for module READMEs, `checkov` for static analysis, `infracost` for cost estimation, `cfn-lint` for CloudFormation, `aws-sam-cli` for SAM (note: `tfsec` checks live in `trivy config`)
+- **AI / agentic**: `claude` (Claude Code) for in-terminal pair programming, `aider` for git-aware AI edit loops, `llm` for one-shot prompts and embeddings, `repomix` to pack a repo into a single LLM-friendly file
 - **HTTP**: `xh` for colorized requests, `curlie` for curl with httpie output, `grpcurl` for gRPC
 - **Network**: `trip` (trippy) for traceroute TUI, `sudo mtr` (requires root, lives in sbin), `bandwhich` for bandwidth, `nmap` for scanning, `mkcert` for local TLS certs
 - **Docs**: `d2` for diagrams, `pandoc` for conversion, `glow` for Markdown preview
@@ -6528,11 +6542,13 @@ DOCKER_RULES
 
 - Use OpenTofu/Terraform with state stored remotely (S3 + DynamoDB)
 - Lint with `tflint` before applying
+- Document modules with `terraform-docs` (auto-generate variable/output sections)
+- Run `checkov -d .` for IaC static analysis (Terraform, CloudFormation, Kubernetes, Dockerfile)
+- Scan with `trivy config .` for misconfigurations (covers what tfsec used to)
 - Estimate costs with `infracost` before applying changes
 - Use modules for reusable infrastructure patterns
 - Tag all resources: project, environment, owner, managed-by
 - Use workspaces or separate state files per environment
-- Scan with `trivy config .` for misconfigurations
 IAC_RULES
 
     success "Claude Code rules created (workflow, git, security, typescript, python, docker, iac)"
@@ -6729,10 +6745,12 @@ CMD_DOCKER
 Review the infrastructure-as-code in this project:
 
 1. Run `tflint` on any Terraform/OpenTofu files
-2. Run `trivy config .` to scan for misconfigurations
-3. Run `infracost breakdown --path .` to estimate costs (if infracost is configured)
-4. Check for: missing tags, overly permissive IAM, unencrypted resources, missing backups
-5. Check CDK code for L1 constructs that should be L2/L3
+2. Run `trivy config .` to scan for misconfigurations (broad surface — IaC + Dockerfile + K8s)
+3. Run `checkov -d .` for IaC-focused static analysis (different rule set than trivy — they're complementary)
+4. Run `infracost breakdown --path .` to estimate costs (if infracost is configured)
+5. If Terraform modules are present, run `terraform-docs markdown table .` and verify the README's variable/output sections are up to date
+6. Check for: missing tags, overly permissive IAM, unencrypted resources, missing backups
+7. Check CDK code for L1 constructs that should be L2/L3
 
 Report findings with severity and recommended fixes.
 CMD_IAC

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -779,6 +779,13 @@ fi
 preflight
 acquire_lock
 
+# Truncate state file on a fresh run so it doesn't accumulate duplicates across
+# repeated invocations. Preserved when --resume is passed so previous successes
+# can short-circuit. (Issue #28)
+if [[ "$RESUME" != "true" ]]; then
+    : > "$STATE_FILE"
+fi
+
 # =============================================================================
 # PREREQUISITES (always runs — required for everything else)
 # =============================================================================


### PR DESCRIPTION
Three small follow-ups from the post-Kiro audit, bundled into one PR because the changes are all small and self-contained.

## Summary

- **#26 — Agentic AI CLI companions** under `dx`: `aider`, `llm`, `repomix`. All install through the existing brew/npm helpers, no special-cased setup. Drop-in companions to Claude Code + Kiro.
- **#27 — IaC tooling round-out**: `terraform-docs` and `checkov`, plus a doc note that `tfsec`'s coverage now lives in `trivy config` (which is already installed under `security`). Wired into the iac rules, the `/iac-review` slash command, and the Claude Code Bash allowlist.
- **#28 — State file truncation**: `~/.local/share/dev-setup/completed-items.txt` was growing unbounded across non-resume runs. Truncate it at the start of every non-resume run; preserve it on `--resume`.

## Changes

### `scripts/setup-dev-tools-mac.sh`

- **State** ([line ~782](scripts/setup-dev-tools-mac.sh#L782)) — `: > "\$STATE_FILE"` after `acquire_lock` when `RESUME != true`.
- **iac module** ([line ~1041](scripts/setup-dev-tools-mac.sh#L1041)) — add `terraform-docs`, `checkov`. Comment that tfsec is folded into trivy.
- **dx module** ([line ~1461](scripts/setup-dev-tools-mac.sh#L1461)) — add `aider`, `llm`, `repomix`.
- **--list rows** — updated `iac` and `dx` summary text.
- **CLAUDE.md template** — new "AI / agentic" line in Available CLI Tools; IaC line gets terraform-docs / checkov / tfsec note.
- **Bash allowlist** — pre-approve `terraform-docs *` and `checkov *`.
- **iac.md rules template** — adds terraform-docs + checkov bullets; reframes trivy bullet to mention tfsec coverage.
- **/iac-review slash command** — now runs trivy + checkov + terraform-docs alongside tflint and infracost.

### `README.md`

- IaC table — terraform-docs, checkov, tfsec footnote.
- AI tools table — aider, llm, repomix.
- Quick-reference list — adds new tools to the AWS & IaC summary line.

## Test plan

- [x] `bash -n scripts/setup-dev-tools-mac.sh` passes (verified locally).
- [x] State-file truncation logic verified on a synthetic harness — empty after non-resume run, preserved verbatim after `--resume` run.
- [ ] Fresh-machine run installs all five new tools (`aider`, `llm`, `repomix`, `terraform-docs`, `checkov`) without errors in `~/.dev-setup.log`.
- [ ] `aider --version`, `llm --version`, `repomix --version`, `terraform-docs --version`, `checkov --version` all return cleanly after run.
- [ ] Two consecutive non-resume runs leave `~/.local/share/dev-setup/completed-items.txt` with the same line count.
- [ ] `--resume` after a partial run sees the prior state file unchanged at start of run.
- [ ] `gh pr create` (or any `git commit` with no `-m`) opens Kiro now that EDITOR is correct (verified in #24 follow-up; relevant here only because aider/llm respect EDITOR too).

Closes #26
Closes #27
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)