### PR TITLE
feat(kiro): wire up AWS MCP servers + AWS Toolkit / cfn-lint extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,8 @@ Auto-installed by the script:
 | **YAML** | YAML language support with validation |
 | **Even Better TOML** | TOML language support |
 | **Terraform (HashiCorp)** | Terraform / OpenTofu language support |
+| **AWS Toolkit** | Local Lambda debugging via SAM, CloudFormation/SAM YAML schemas, ECS exec terminal, AWS resource explorer (S3/Lambda/CloudWatch), credential/SSO management ([OpenVSX](https://open-vsx.org/extension/amazonwebservices/aws-toolkit-vscode)) |
+| **cfn-lint** | CloudFormation/SAM template linter — pairs with the `cfn-lint` CLI |
 
 ### Kiro Settings Highlights
 

--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ The script generates config files with sensible defaults:
 | `~/.gemrc` | Ruby | No docs on gem install |
 | `~/Library/.../Kiro/User/settings.json` | Kiro | Dracula, JetBrains Mono, format on save, file nesting, bracket pair colorization, per-language formatters (ruff for Python, go for Go, rust-analyzer for Rust), agent + MCP toggles |
 | `~/Library/.../Kiro/User/keybindings.json` | Kiro | Custom keyboard shortcuts (incl. ⌘I open agent, ⌘⇧I inline edit, ⌘⇧S create spec) |
-| `~/.kiro/settings/mcp.json` | Kiro MCP | Global MCP servers: filesystem, github, git, fetch, context7, aws-docs (playwright + postgres written disabled) |
+| `~/.kiro/settings/mcp.json` | Kiro MCP | Global MCP servers — enabled: filesystem, github, git, fetch, context7, notion, aws-docs, aws-pricing, aws-iac, aws-knowledge, cloudwatch, iam. Disabled (opt-in): playwright, postgres, aws-ccapi, aws-serverless, aws-lambda-tool, aws-eks, aws-ecs, aws-dynamodb |
 | `~/Library/.../lazygit/config.yml` | lazygit | Dracula theme, delta pager, nerd fonts, auto-fetch, Kiro editor (`kiro --goto`), rounded borders |
 | `~/Library/.../k9s/skins/dracula.yaml` | k9s | Full Dracula skin |
 
@@ -1002,18 +1002,45 @@ The script writes a sensible default `~/.kiro/settings/mcp.json` with these enab
 | **fetch** | HTTP fetch with HTML→Markdown conversion | `mcp-server-fetch` (uvx) |
 | **context7** | Fetch up-to-date library docs by package name | `@upstash/context7-mcp` (npx) |
 | **aws-docs** | Search and read AWS documentation | `awslabs.aws-documentation-mcp-server` (uvx) |
+| **aws-pricing** | Pre-deployment cost estimation ("what would this CDK stack cost?") | `awslabs.aws-pricing-mcp-server` (uvx) — no AWS credentials needed |
+| **aws-iac** | CDK + Terraform + CloudFormation patterns, security guidance, cdk-nag | `awslabs.aws-iac-mcp-server` (uvx) — replaces deprecated cdk-mcp-server |
+| **aws-knowledge** | Broader AWS knowledge base — services overview, best practices, FAQs | `awslabs.aws-knowledge-mcp-server` (uvx) |
+| **cloudwatch** | Query CloudWatch Logs + metrics, inspect alarm state | `awslabs.cloudwatch-mcp-server` (uvx); needs AWS creds; only read-only ops auto-approved |
+| **iam** | Read IAM users, roles, groups, policies; simulate principal policies | `awslabs.iam-mcp-server` (uvx); needs AWS creds; **only `list_*` / `get_*` / `simulate_*` auto-approved — every mutation prompts** |
 | **notion** | Search Notion pages/databases, read blocks, retrieve users | `@notionhq/notion-mcp-server` (npx); needs `NOTION_TOKEN` from an internal integration |
 
-And these are written **disabled** — flip `"disabled": false` to opt in:
+And these are written **disabled** — flip `"disabled": false` to opt in per-workspace:
 
 | Server | Why disabled by default |
 |--------|-------------------------|
 | **playwright** | Spawns a real browser; only enable when doing E2E work |
 | **postgres** | Needs a running database and connection string |
+| **aws-ccapi** | AWS Cloud Control API — full CRUD on any supported resource. Extreme blast radius; enable per-workspace when actively doing infra work |
+| **aws-serverless** | Full SAM application lifecycle (build, deploy, invoke). Mutates Lambda/API GW/etc. |
+| **aws-lambda-tool** | Calls your *already-deployed* Lambdas as MCP tools. Different shape — for using Lambdas as agent tools, not deploying them |
+| **aws-eks** | EKS cluster + Kubernetes resource management |
+| **aws-ecs** | ECS task / service deployment |
+| **aws-dynamodb** | DynamoDB table operations and data access |
 
 Edit `~/.kiro/settings/mcp.json` to add more (Linear, Slack, Sentry, Stripe, etc.) or override per-project at `<repo>/.kiro/settings/mcp.json` — workspace config wins.
 
 **Notion setup:** create an internal integration at <https://www.notion.so/profile/integrations>, copy the `secret_...` token, export it (`echo 'export NOTION_TOKEN=secret_...' >> ~/.zshrc.local`), then share the specific Notion pages/databases you want the agent to reach via the page's `…` menu → "Connect to" → your integration. Without page access the integration sees nothing; this is the intended Notion permission model.
+
+**AWS setup:** the AWS servers use the standard AWS credential chain — anything that works for `aws sts get-caller-identity` works here. Three common setups:
+
+```bash
+# 1) Long-lived access keys (least preferred)
+aws configure                       # writes ~/.aws/credentials
+
+# 2) AWS SSO via `granted` (installed under the `aws` module)
+assume <profile>                    # exports AWS_PROFILE for the shell
+
+# 3) Per-shell env vars (CI-style)
+export AWS_REGION=us-east-1
+export AWS_PROFILE=my-dev-account
+```
+
+Kiro reads `${AWS_REGION}` and `${AWS_PROFILE}` from the shell that launched it at startup. If you change profile mid-session, restart Kiro (or use `Kiro: Reload Window`). The pre-approved `autoApprove` list for `iam` covers only read/simulate operations — every IAM mutation (`create_role`, `attach_role_policy`, etc.) will still prompt for confirmation.
 
 ---
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -2516,6 +2516,9 @@ if installed kiro; then
         "redhat.vscode-yaml"
         "tamasfe.even-better-toml"
         "hashicorp.terraform"
+        # AWS development
+        "amazonwebservices.aws-toolkit-vscode"
+        "kddejong.vscode-cfn-lint"
     )
     for ext in "${KIRO_EXTENSIONS[@]}"; do
         if kiro --list-extensions 2>/dev/null | grep -qi "$ext"; then

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -2602,6 +2602,58 @@ else
       "disabled": false,
       "autoApprove": ["search_documentation", "read_documentation"]
     },
+    "aws-pricing": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.aws-pricing-mcp-server@latest"],
+      "disabled": false,
+      "autoApprove": ["*"]
+    },
+    "aws-iac": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.aws-iac-mcp-server@latest"],
+      "disabled": false,
+      "autoApprove": ["*"]
+    },
+    "aws-knowledge": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.aws-knowledge-mcp-server@latest"],
+      "disabled": false,
+      "autoApprove": ["*"]
+    },
+    "cloudwatch": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.cloudwatch-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": false,
+      "autoApprove": [
+        "describe_alarms", "describe_alarm_history", "list_metrics",
+        "get_metric_data", "get_metric_statistics",
+        "describe_log_groups", "describe_log_streams", "get_log_events",
+        "start_query", "get_query_results", "describe_queries",
+        "describe_metric_filters"
+      ]
+    },
+    "iam": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.iam-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": false,
+      "autoApprove": [
+        "list_users", "list_roles", "list_groups", "list_policies",
+        "list_attached_role_policies", "list_role_policies",
+        "list_attached_user_policies", "list_attached_group_policies",
+        "get_user", "get_role", "get_group", "get_policy",
+        "get_role_policy", "get_user_policy", "get_policy_version",
+        "get_account_summary", "get_account_authorization_details",
+        "simulate_principal_policy", "simulate_custom_policy"
+      ]
+    },
     "notion": {
       "command": "$KIRO_NPX",
       "args": ["-y", "@notionhq/notion-mcp-server"],
@@ -2622,13 +2674,80 @@ else
       "args": ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost:5432/postgres"],
       "disabled": true,
       "autoApprove": []
+    },
+    "aws-ccapi": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.ccapi-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": true,
+      "autoApprove": []
+    },
+    "aws-serverless": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.aws-serverless-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": true,
+      "autoApprove": []
+    },
+    "aws-lambda-tool": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.lambda-tool-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": true,
+      "autoApprove": []
+    },
+    "aws-eks": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.eks-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": true,
+      "autoApprove": []
+    },
+    "aws-ecs": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.ecs-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": true,
+      "autoApprove": []
+    },
+    "aws-dynamodb": {
+      "command": "$KIRO_UVX",
+      "args": ["awslabs.dynamodb-mcp-server@latest"],
+      "env": {
+        "AWS_REGION": "\${AWS_REGION}",
+        "AWS_PROFILE": "\${AWS_PROFILE}"
+      },
+      "disabled": true,
+      "autoApprove": []
     }
   }
 }
 KIRO_MCP_CONF
-    success "Kiro MCP config created (filesystem, github, git, fetch, context7, aws-docs, notion enabled; playwright + postgres disabled by default)"
+    success "Kiro MCP config created"
+    info "  Enabled: filesystem, github, git, fetch, context7, notion, aws-docs,"
+    info "           aws-pricing, aws-iac, aws-knowledge, cloudwatch, iam"
+    info "  Disabled (opt-in per project): playwright, postgres, aws-ccapi,"
+    info "           aws-serverless, aws-lambda-tool, aws-eks, aws-ecs, aws-dynamodb"
     info "  Edit $KIRO_MCP to enable more servers or change scope"
-    info "  Notion: export NOTION_TOKEN=secret_... (create an internal integration at https://www.notion.so/profile/integrations)"
+    info "  Notion: export NOTION_TOKEN=secret_... (https://www.notion.so/profile/integrations)"
+    info "  AWS:    AWS servers use the standard AWS credential chain — works with"
+    info "           ~/.aws/credentials, AWS SSO, or 'assume <profile>' (granted)."
+    info "           Set AWS_REGION and AWS_PROFILE in your shell to scope requests."
 fi
 
 # ---- Fonts (required for icons in eza, starship, lazygit, etc.) ----


### PR DESCRIPTION
Wire up the awslabs MCP server fleet and the OpenVSX-published AWS Toolkit into Kiro for serious AWS dev work.

## Summary

- **11 new AWS MCP servers** in `~/.kiro/settings/mcp.json` — 5 enabled by default (read-only / no creds or autoApprove-reads-only) + 6 disabled by default (mutate AWS resources, opt-in per workspace)
- **2 new Kiro extensions** (OpenVSX-verified) — AWS Toolkit and cfn-lint

## MCP servers added

### Enabled by default — Tier 1 (no AWS credentials needed)

| Server | Purpose |
|--------|---------|
| `awslabs.aws-pricing-mcp-server` | Pre-deployment cost estimation ("what would this CDK stack cost monthly?") |
| `awslabs.aws-iac-mcp-server` | CDK + Terraform + CloudFormation patterns, cdk-nag guidance. Replaces the deprecated `cdk-mcp-server` |
| `awslabs.aws-knowledge-mcp-server` | Broader knowledge base than docs alone |

### Enabled by default — Tier 2 (needs AWS credentials; only read ops auto-approved)

| Server | Auto-approved tool patterns |
|--------|----------------------------|
| `awslabs.cloudwatch-mcp-server` | `describe_alarms`, `list_metrics`, `get_metric_data`, `get_log_events`, `start_query` / `get_query_results`, etc. |
| `awslabs.iam-mcp-server` | `list_*`, `get_*`, `simulate_principal_policy`, `simulate_custom_policy`. **Every IAM mutation still prompts.** |

### Disabled by default — Tier 3 (mutates AWS resources, opt-in per workspace)

`awslabs.ccapi-mcp-server` (Cloud Control API — full CRUD), `awslabs.aws-serverless-mcp-server` (SAM lifecycle), `awslabs.lambda-tool-mcp-server` (call deployed Lambdas as agent tools), `awslabs.eks-mcp-server`, `awslabs.ecs-mcp-server`, `awslabs.dynamodb-mcp-server`.

Flip `"disabled": false` in `~/.kiro/settings/mcp.json` (global) or `<repo>/.kiro/settings/mcp.json` (workspace) to enable.

## Kiro extensions added (OpenVSX-verified)

- **[amazonwebservices.aws-toolkit-vscode](https://open-vsx.org/extension/amazonwebservices/aws-toolkit-vscode)** — local Lambda debugging via SAM, CloudFormation/SAM YAML schemas, ECS exec terminal, AWS resource explorer (S3/Lambda/CloudWatch), credential/SSO management. Most impactful single AWS extension.
- **kddejong.vscode-cfn-lint** — CloudFormation/SAM template linter. Pairs with the `cfn-lint` CLI already installed under the `aws` module.

**Deliberately skipped:** `amazonwebservices.amazon-q-vscode`. Kiro has its own built-in Claude agent and we already install Claude Code — three agents felt like too many. Trivial to add per user preference.

## AWS credentials

The Tier 2 + Tier 3 servers use the standard AWS credential chain. Three common setups (documented in README):

```bash
aws configure                # ~/.aws/credentials
assume <profile>             # AWS SSO via granted (already installed)
export AWS_REGION=us-east-1  # explicit env vars
export AWS_PROFILE=my-dev
```

`AWS_REGION` and `AWS_PROFILE` are referenced via `\${VAR}` in the JSON `env` blocks — Kiro substitutes from the shell that launched it.

## Verified locally

- [x] `bash -n` passes
- [x] Generated JSON parses through `jq` — 20 servers total, 12 enabled, 8 disabled
- [x] All paths pre-expand (`$KIRO_UVX` → `/opt/homebrew/bin/uvx`, `$HOME/Code` → real path)
- [x] All tokens stay literal (`\${GITHUB_TOKEN}`, `\${NOTION_TOKEN}`, `\${AWS_REGION}`, `\${AWS_PROFILE}`)
- [x] Server names match the canonical `awslabs/mcp/src/` directory listing on GitHub
- [x] AWS Toolkit confirmed on OpenVSX

## Caveats

- **autoApprove tool names** for cloudwatch + iam follow boto3 conventions. If the upstream MCP server publishes different tool names, users will see one extra prompt per tool — no functional break, easy fix per real-machine test (#25 will cover this).
- **`@latest`** version pin on the awslabs servers — `uvx` re-resolves on each invocation but caches locally. Standard pattern from the awslabs docs.

## Test plan

- [ ] Fresh run: all extensions install from OpenVSX without errors (verify in `~/.dev-setup.log`)
- [ ] Launch Kiro from Finder (not terminal): `aws-pricing`, `aws-iac`, `aws-knowledge`, `aws-docs` MCP servers spawn (no creds needed, easiest to test)
- [ ] With `~/.aws/credentials` configured: `iam` and `cloudwatch` servers respond to a read query (e.g., "list my IAM roles", "show me CW alarms in us-east-1")
- [ ] Auto-approve coverage: a read operation does not prompt; a write (e.g., `create_role`) prompts
- [ ] AWS Toolkit extension shows the AWS Explorer panel and connects via a configured profile
- [ ] cfn-lint extension flags errors in a SAM template with a known mistake

## Future

#25 already tracks fresh-Mac validation; this PR's deferred verification rolls into that ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)