### PR TITLE
chore(release): bump version to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [4.1.0] - 2026-05-10
+
+Minor release rolling up two follow-up PRs to v4.0.0: a tool-discoverability audit (#31) and the AWS MCP / toolkit fleet (#32). Fully backward-compatible.
+
+### Added
+
+- **kiro/mcp**: Add 11 AWS MCP servers backed by [awslabs/mcp](https://awslabs.github.io/mcp/). Five enabled by default (read-only or autoApprove-reads-only): `aws-pricing` (no AWS creds needed), `aws-iac` (CDK + Terraform + CloudFormation patterns, replaces the deprecated cdk-mcp-server), `aws-knowledge` (broader knowledge base), `cloudwatch` (Logs/Metrics queries, read ops only auto-approved), `iam` (read/simulate only auto-approved — every mutation still prompts). Six written disabled-by-default for opt-in per workspace: `aws-ccapi` (Cloud Control API CRUD), `aws-serverless` (SAM lifecycle), `aws-lambda-tool` (call deployed Lambdas as agent tools), `aws-eks`, `aws-ecs`, `aws-dynamodb`. All use `${AWS_REGION}` / `${AWS_PROFILE}` from the launching shell (#32)
+- **kiro/extensions**: Add `amazonwebservices.aws-toolkit-vscode` (local Lambda debugging via SAM, CloudFormation/SAM YAML schemas, ECS exec terminal, AWS resource explorer, credential/SSO management) and `kddejong.vscode-cfn-lint` (template linter, pairs with the `cfn-lint` CLI). Both verified on OpenVSX (#32)
+- **docs**: README documents the AWS credential setup chain (`aws configure`, AWS SSO via `granted`/`assume`, explicit env vars) and the Notion integration sharing model (#32)
+
+### Fixed
+
+- **path**: Add `~/.local/bin` to `.zprofile` and the managed `.zshrc` block. `uv tool install` (and `pipx`) put persistent binaries there — without this, `harlequin` and anything else the user installs via `uv tool install` was unreachable as a bare command (#31)
+- **kiro/mcp**: Pre-expand `npx` and `uvx` to absolute paths in `~/.kiro/settings/mcp.json`. Kiro is a GUI app; when launched from Finder, Spotlight, or Raycast it inherits launchd's restricted PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), not the user's interactive shell PATH. Bare `"command": "npx"` silently failed to spawn MCP servers for any user who didn't launch Kiro from a terminal — the most common launch path. Same well-known issue as Claude Desktop. Resolution chain falls back to `/opt/homebrew/bin` then `/usr/local/bin` if `brew --prefix` fails (#31)
+- **claude**: Refresh the Claude Code Bash permission allowlist with 36 entries covering v4.0.0 additions (`kiro`, `aider`, `llm`, `repomix`, `uvx`) plus 30+ tools installed by earlier versions that had never been allowlisted (`mas`, `dockutil`, `terminal-notifier`, `harlequin`, `granted`, `assume`, `topgrade`, `git-absorb`, `mkcert`, `mitmproxy`, `bandwhich`, `nmap`, `procs`, `btop`, `trash`, `yt-dlp`, `parallel`, `lnav`, `glow`, `fastfetch`, etc.). 169 allow entries total. `claude *` deliberately excluded as recursive (#31)
+
 ## [4.0.0] - 2026-05-10
 
 **BREAKING:** VS Code is replaced with **Kiro** (AWS's agentic IDE — VS Code fork with built-in Claude agent, specs, steering, hooks, MCP). Re-running the script on a v3.x machine will leave VS Code in place but switch the toolchain (`EDITOR`, lazygit, yazi, `gh`) to point at `kiro`. Run `--cleanup` to also uninstall the now-deprecated `visual-studio-code` cask.

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -10,7 +10,7 @@
 # Flags:    --dry-run, --list, --skip <cats>, --only <cats>, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="4.0.0"
+SCRIPT_VERSION="4.1.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 


### PR DESCRIPTION
Release PR for **v4.1.0**. Minor bump, fully backward-compatible with v4.0.0.

## Summary

Two PRs have merged to main since v4.0.0:

- **#31** — `fix: PATH, MCP server paths, and Claude allowlist (X+Y+Z audit)`
- **#32** — `feat(kiro): wire up AWS MCP servers + AWS Toolkit / cfn-lint extensions`

Both fully backward-compatible. Mixed bugfixes + features → minor bump (4.0.0 → 4.1.0).

## What ships in v4.1.0

### Tool discoverability (#31)

- `~/.local/bin` added to PATH so `uv tool install` binaries (harlequin today) are reachable
- MCP server `command` fields are absolute paths (`/opt/homebrew/bin/npx`, `/opt/homebrew/bin/uvx`) so they spawn correctly when Kiro is launched from Finder/Spotlight/Raycast — not just from a terminal. **Affects most users.**
- Claude Code Bash allowlist refreshed with 36 entries (kiro, aider, llm, repomix, uvx, mas, dockutil, harlequin, granted, topgrade, btop, trash, yt-dlp, glow, fastfetch, and more)

### AWS dev work (#32)

- **11 AWS MCP servers** under `~/.kiro/settings/mcp.json`:
  - **Enabled by default (5):** `aws-pricing`, `aws-iac`, `aws-knowledge`, `cloudwatch`, `iam` (read-only ops auto-approved)
  - **Disabled by default (6):** `aws-ccapi`, `aws-serverless`, `aws-lambda-tool`, `aws-eks`, `aws-ecs`, `aws-dynamodb`
- **2 Kiro extensions** from OpenVSX:
  - `amazonwebservices.aws-toolkit-vscode` — local Lambda debug, CFN schemas, ECS terminal, AWS resource explorer
  - `kddejong.vscode-cfn-lint` — CloudFormation/SAM template linter
- AWS credentials work via the standard chain — `~/.aws/credentials`, AWS SSO via `granted`/`assume`, or `AWS_REGION`/`AWS_PROFILE` env vars

## Not blocking on #25

Issue #25 (fresh-Mac validation) tracks real-machine smoke testing of the new MCP servers, OpenVSX extensions, and PATH changes. Tier 1 + Tier 2 items can land in a v4.1.1 follow-up if anything turns up — they're not blocking the release.

## Changes in this PR

- `SCRIPT_VERSION` 4.0.0 → 4.1.0
- CHANGELOG entry for v4.1.0 with Added / Fixed sections, full PR references

## Next step (after merge)

```bash
git tag -a v4.1.0 -m "Release v4.1.0"
git push origin v4.1.0
```

Triggers `.github/workflows/release.yml` → builds `vixygrey-dev-setup-macos-v4.1.0.zip` + creates GitHub Release.

## Test plan

- [x] `bash -n scripts/setup-dev-tools-mac.sh` passes
- [x] CHANGELOG entry follows existing format (date, Added/Fixed sections, PR refs)
- [x] Minor version bump consistent — additions are new features (AWS MCP), bugfixes are non-breaking (PATH, allowlist)
- [ ] After merge + tag push, GitHub Release artifact builds and `vixygrey-dev-setup-macos-v4.1.0.zip` attaches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)