### PR TITLE
chore(release): bump version to 5.0.0

### DIFF
--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -10,7 +10,7 @@
 # Flags:    --dry-run, --list, --skip <cats>, --only <cats>, --interactive, --cleanup, --help
 # =============================================================================
 
-SCRIPT_VERSION="4.1.0"
+SCRIPT_VERSION="5.0.0"
 SCRIPT_START=$(date +%s)
 PYTHON_VERSION="3.12"
 


### PR DESCRIPTION
## Summary

- Bump SCRIPT_VERSION to 5.0.0

## What's in 5.0.0

- **Install fixes**: `--adopt` for brew casks, repomix switched to Homebrew formula, cleanup handles non-Homebrew apps (#34)
- **DX/UX audit**: 70+ `is_done`/`mark_done` additions for `--resume` idempotency, silent failure fixes, install guards on config writes, progress bar accuracy (#34)
- **Interactive mode**: `--interactive` / `-i` flag with gum TUI picker or numbered fallback menu (#36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)