### PR TITLE
chore: curate toolset, restructure filesystem, update Claude config

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 | **usql** | Universal SQL CLI -- connects to Postgres, MySQL, SQLite, and more |
 | **sq** | jq for databases -- query SQLite, Postgres, CSV from one tool |
 | **dbmate** | Lightweight, framework-agnostic database migration tool |
-| **TablePlus** | Native macOS database GUI -- fast, clean, supports 20+ databases |
+| **DBeaver** | Free, open-source universal database GUI -- supports nearly every database and driver |
 
 ---
 
@@ -329,7 +329,7 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 
 | Tool | Description |
 |------|-------------|
-| **Postman** | Industry-standard API client -- collections, environments, scripting |
+| **Bruno** | Local-first, git-friendly API client -- collections stored as plain-text files |
 | **grpcurl** | curl for gRPC services |
 
 ---
@@ -356,6 +356,7 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 | **atuin** | Replaces shell history with SQLite-backed, fuzzy-searchable database |
 | **mise** | Universal version manager -- Node, Python, Go, Ruby all in one (replaces nvm + pyenv + rbenv) |
 | **Kiro** | Primary code editor and IDE — VS Code fork with built-in Claude agent (specs, steering, hooks, MCP) |
+| **Visual Studio Code** | Secondary editor — installed with the same extension set as Kiro (from the Microsoft Marketplace) |
 | **Claude Code** | AI-assisted coding in the terminal (Anthropic, agentic) |
 | **GitHub Copilot CLI** | AI suggestions in the terminal (via `gh copilot suggest`) |
 | **aider** | Terminal AI pair programmer -- git-aware edit loops, complementary to Claude Code |
@@ -386,6 +387,7 @@ Faster, prettier, smarter replacements for standard Unix utilities.
 |------|-------------|
 | **d2** | Code-to-diagram scripting language -- declarative diagrams as code |
 | **Mermaid CLI** | Render Mermaid diagrams (flowcharts, sequences, ERDs) from CLI |
+| **draw.io** | Open-source desktop diagram editor -- architecture & system diagrams (offline) |
 
 ---
 
@@ -434,20 +436,10 @@ Preview files in Finder by pressing spacebar.
 |-----|-------------|
 | **Notion** | All-in-one workspace -- docs, wikis, databases, project tracking |
 | **Notion Calendar** | Calendar app with Notion integration |
-| **Notion Mail** | Email client with Notion integration |
-| **Snagit** | Screenshots, scrolling capture, annotations, and video recording |
+| **Shottr** | Fast native screenshots -- scrolling capture, OCR, annotations (local-only, no account) |
 | **Claude** | AI assistant |
 | **Skim** | Lightweight PDF reader with annotations -- faster than Preview |
-| **Transmit** | Premium SFTP/S3 file transfer client -- fast, dual-pane |
-
----
-
-## Mac Apps -- Communication
-
-| App | Description |
-|-----|-------------|
-| **Slack** | Team messaging and collaboration |
-| **Telegram** | Encrypted messaging with channels and bots |
+| **Cyberduck** | Free, open-source SFTP/S3/cloud file transfer |
 
 ---
 
@@ -456,8 +448,6 @@ Preview files in Finder by pressing spacebar.
 | App | Description |
 |-----|-------------|
 | **Google Chrome** | Primary Chromium browser for development and DevTools |
-| **Firefox** | Privacy-focused browser for cross-browser testing |
-| **Brave** | Privacy-focused Chromium browser with built-in ad blocking |
 
 ---
 
@@ -469,7 +459,6 @@ Preview files in Finder by pressing spacebar.
 | **oxipng** | Lossless PNG compression -- CLI, scriptable, CI-friendly |
 | **jpegoptim** | Lossless JPEG compression -- strip metadata, optimize |
 | **p7zip** | Archive tool -- zip, 7z, rar, tar from the command line |
-| **LibreOffice** | Free office suite -- documents, spreadsheets, presentations |
 
 ---
 
@@ -618,11 +607,16 @@ Destructive commands are blocked:
 
 ## Filesystem Structure
 
-The scripts create an organized directory layout for both development and personal use:
+The scripts create a deliberately **ADD-friendly** directory layout: few top-level
+roots, shallow nesting, no overlapping categories, and an `~/Inbox` dump zone so
+nothing has to be filed in the moment. When in doubt, drop it in `Inbox` (or use
+Spotlight to find things) rather than agonizing over where it "should" go.
 
 ```
 ~/
-|-- Code/                        # -- Development --
+|-- Inbox/                       # Dump zone — drop ANYTHING here, sort later or never
+|
+|-- Code/                        # -- Development (unchanged) --
 |   |-- work/                    # Work projects
 |   |   |-- <org-name>/          # Grouped by GitHub org
 |   |   +-- scratch/             # Throwaway experiments
@@ -639,47 +633,24 @@ The scripts create an organized directory layout for both development and person
 |
 |-- Screenshots/                 # Screenshots save here
 |
-|-- Documents/                   # -- Life Admin --
-|   |-- finance/
-|   |   |-- taxes/               # Tax returns, W-2s, 1099s
-|   |   |-- invoices/            # Sent/received invoices
-|   |   +-- statements/          # Bank/credit card statements
+|-- Docs/                        # -- Life Admin (a few flat buckets) --
+|   |-- finance/                 # Statements, taxes, invoices
 |   |-- health/                  # Medical records, insurance cards
-|   |-- legal/                   # Contracts, agreements, legal docs
-|   |-- travel/                  # Itineraries, bookings, visa docs
-|   |-- insurance/               # Policies, claims
-|   |-- contracts/               # Work/freelance contracts
+|   |-- admin/                   # Legal, insurance, contracts
 |   |-- receipts/                # Purchase receipts, warranties
-|   +-- design/                  # Design files, mockups
+|   +-- travel/                  # Itineraries, bookings
 |
-|-- Reference/                   # -- Quick-Access Knowledge --
-|   |-- manuals/                 # Product/software manuals
-|   |-- cheatsheets/             # CLI, language, tool cheatsheets
-|   +-- bookmarks-export/        # Exported browser bookmarks
-|
-|-- Creative/                    # -- Creative Work --
-|   |-- design/                  # Graphic design projects
+|-- Creative/                    # -- Creative Work (flat) --
 |   |-- writing/                 # Blog posts, drafts, notes
-|   |-- video-editing/           # Video projects, raw footage
-|   +-- assets/
-|       |-- icons/               # Icon collections
-|       |-- fonts/               # Custom/downloaded fonts
-|       |-- stock-photos/        # Stock imagery
-|       +-- templates/           # Document/design templates
+|   |-- design/                  # Graphic/design projects, mockups, assets
+|   +-- video/                   # Video projects, raw footage
 |
 |-- Media/                       # -- Personal Media --
-|   |-- photos/                  # Personal photos
-|   |-- videos/                  # Personal videos
-|   |-- music/                   # Music files
-|   +-- wallpapers/              # Desktop/phone wallpapers
+|   |-- photos/
+|   |-- videos/
+|   +-- music/
 |
-|-- Projects/                    # -- Non-Code Projects --
-|   |-- side-hustles/            # Business/freelance projects
-|   +-- home/                    # Home improvement, DIY
-|
-+-- Archive/                     # -- Cold Storage --
-    |-- old-projects/            # Completed/abandoned projects
-    +-- old-docs/                # Old documents for reference
++-- Archive/                     # Cold storage — one bucket for old/done stuff
 ```
 
 ### Helper Scripts (~/Scripts/bin/)

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -862,18 +862,11 @@ sops --decrypt secrets.yaml  # decrypt to stdout
 3. **Enable Clipboard History:** Raycast Settings > Extensions > Clipboard History > enable
 4. **Window management:** Raycast Settings > Extensions > Window Management > enable (replaces Rectangle)
 
-### Brave Browser
+### Google Chrome
 
-1. **Import bookmarks:** Brave Settings > Bookmarks > Import
-2. **Extensions:** uBlock Origin (pre-installed), React DevTools, axe DevTools, JSON Formatter, Lighthouse
-3. **Privacy:** Settings > Shields > Aggressive mode for trackers
-4. **Default search:** Settings > Search engine > DuckDuckGo or Brave Search
-
-### Firefox
-
-1. **Privacy:** Settings > Privacy & Security > Strict tracking protection
-2. **Extensions:** uBlock Origin, React DevTools, axe DevTools
-3. **Developer tools:** Settings > Developer Tools > enable browser console
+1. **Import bookmarks:** Chrome Settings > Bookmarks > Import bookmarks and settings
+2. **Extensions:** uBlock Origin, React DevTools, axe DevTools, JSON Formatter, Lighthouse
+3. **Default search:** Settings > Search engine > DuckDuckGo
 
 ### Ghostty (Terminal)
 
@@ -899,20 +892,21 @@ Already configured by the script (Dracula theme, JetBrains Mono, format on save,
 
 Kiro is the IDE-native agent (UI surface, specs, hooks, inline edit). Claude Code is the terminal-native agent (full repo context, long-running tasks, automation). They share the same file system and can be used together — let Kiro handle interactive editing and Claude Code handle batch refactors, ultrareview, and CI-driven loops. Steering rules under `.kiro/steering/` are read by Kiro; the same content can live in `CLAUDE.md` for Claude Code.
 
-### TablePlus
+### DBeaver
 
-1. **Add connections:** Click "+" to add database connections
-2. **Keyboard shortcuts:** Cmd+Enter to run query, Cmd+S to save
-3. **Theme:** Preferences > Appearance > Dark mode
-4. **Export:** Right-click table > Export (CSV, JSON, SQL)
+1. **Add connections:** Database > New Database Connection > pick your driver (DBeaver downloads it on first use)
+2. **Keyboard shortcuts:** Ctrl+Enter to run query, Cmd+S to save SQL scripts
+3. **Theme:** Preferences > User Interface > Appearance > Dark theme
+4. **Export:** Right-click a table/result > Export Data (CSV, JSON, SQL, XLSX)
 
-### Postman (API Client)
+### Bruno (API Client)
 
-1. **Sign in:** Sign in with your Postman account to sync collections across devices
-2. **Create a collection:** New > Collection > organize requests by service or feature
-3. **Environments:** Environments tab > add dev/staging/prod with variables
-4. **Tests:** Each request supports pre-request and test scripts (Tests tab)
-5. **Import:** File > Import supports OpenAPI, cURL, and other Postman exports
+1. **Pick a collection location:** Create a collection and point it at a folder in your repo — requests are saved as plain-text `.bru` files you commit alongside your code (no account or cloud sync).
+2. **Create a collection:** New Collection > organize requests by service or feature.
+3. **Environments:** Add dev/staging/prod environments with variables; keep secrets in `.env` (Bruno reads process env), not in committed files.
+4. **Tests:** Each request supports pre-request and post-response scripts plus assertions.
+5. **Import:** File > Import supports OpenAPI, cURL, Insomnia, and **Postman collections** — export your Postman collections and import them here before uninstalling Postman.
+6. **CI:** Use the `bru` CLI (`npm i -g @usebruno/cli`) to run collections in GitHub Actions.
 
 ### Notion
 
@@ -920,13 +914,6 @@ Kiro is the IDE-native agent (UI surface, specs, hooks, inline edit). Claude Cod
 2. **Templates:** Explore template gallery for project management, docs, wikis
 3. **Integrations:** Settings > Integrations > connect Slack, GitHub
 4. **Web clipper:** Install Notion Web Clipper browser extension
-
-### Slack
-
-1. **Workspaces:** Add all your team workspaces
-2. **Keyboard shortcuts:** Cmd+K (quick switch), Cmd+Shift+M (mentions)
-3. **Notifications:** Preferences > Notifications > customize per-channel
-4. **Sidebar:** Organize channels with sections
 
 ### Mullvad VPN
 
@@ -936,12 +923,12 @@ Kiro is the IDE-native agent (UI surface, specs, hooks, inline edit). Claude Cod
 4. **DNS:** Settings > VPN settings > Use custom DNS if needed
 5. **Server:** Choose server location close to you for best performance
 
-### Snagit
+### Shottr
 
-1. **Capture hotkey:** Preferences > Capture > set to `Ctrl+Shift+4` (or your preference)
-2. **Output folder:** Preferences > Share > set default save location to `~/Screenshots`
-3. **Editor:** Configure annotation defaults (font, colors, arrow style)
-4. **Video:** Enable system audio recording if needed
+1. **Capture hotkey:** Preferences > Shortcuts > set area/scrolling capture keys (or remap the macOS `Cmd+Shift` defaults)
+2. **Output folder:** Preferences > General > set default save location to `~/Screenshots`
+3. **Annotations:** Built-in editor for arrows, blur/pixelate, and measurements after each capture
+4. **OCR:** Use "Copy text" on any capture to pull text straight out of the image
 
 ### UniFi Identity Endpoint
 

--- a/scripts/setup-dev-tools-mac.sh
+++ b/scripts/setup-dev-tools-mac.sh
@@ -189,7 +189,6 @@ ALL_CATEGORIES=(
     docs
     mac-system
     mac-productivity
-    mac-communication
     mac-browsers
     mac-media
     mac-cloud
@@ -217,18 +216,17 @@ declare -A CATEGORY_DESC=(
     [dev-servers]="ngrok, miniserve, caddy"
     [terminal-productivity]="glow, watchexec, gum, nushell, topgrade, fastfetch"
     [k8s-github]="stern, gh-dash"
-    [database]="pgcli, mycli, lazysql, harlequin, usql, sq, TablePlus"
+    [database]="pgcli, mycli, lazysql, harlequin, usql, sq, DBeaver"
     [containers]="lazydocker, dive, kubectl, k9s"
-    [api]="Postman, grpcurl"
+    [api]="Bruno, grpcurl"
     [networking]="mtr, bandwhich, nmap"
-    [dx]="fzf, starship, atuin, Kiro, Ghostty, zellij, Raycast, aider, llm"
+    [dx]="fzf, starship, atuin, Kiro, VS Code, Ghostty, zellij, Raycast, aider, llm"
     [ux]="Lighthouse"
-    [docs]="d2, Mermaid CLI"
+    [docs]="d2, Mermaid CLI, draw.io"
     [mac-system]="Pearcleaner, Quick Look plugins, dockutil"
-    [mac-productivity]="Notion, Skim, Transmit"
-    [mac-communication]="Slack, Telegram"
-    [mac-browsers]="Firefox, Brave, Carbonyl, w3m"
-    [mac-media]="mpv, oxipng, jpegoptim, 7zip, LibreOffice, cmus"
+    [mac-productivity]="Notion, Skim, Cyberduck"
+    [mac-browsers]="Carbonyl, w3m"
+    [mac-media]="mpv, oxipng, jpegoptim, 7zip, cmus"
     [mac-cloud]="Google Drive, rclone, borg"
     [mac-focus]="newsboat"
     [mac-bloat]="Remove pre-installed Apple apps (GarageBand)"
@@ -386,18 +384,17 @@ list_categories() {
     printf "  %-25s %s\n" "dev-servers"         "ngrok, miniserve, caddy"
     printf "  %-25s %s\n" "terminal-productivity" "glow, watchexec, pv, parallel, gum, nushell, topgrade, fastfetch, nnn, progress"
     printf "  %-25s %s\n" "k8s-github"          "stern, gh-dash"
-    printf "  %-25s %s\n" "database"            "pgcli, mycli, lazysql, harlequin, usql, sq, TablePlus"
+    printf "  %-25s %s\n" "database"            "pgcli, mycli, lazysql, harlequin, usql, sq, DBeaver"
     printf "  %-25s %s\n" "containers"          "lazydocker, dive, kubectl, k9s"
-    printf "  %-25s %s\n" "api"                 "Postman, grpcurl"
+    printf "  %-25s %s\n" "api"                 "Bruno, grpcurl"
     printf "  %-25s %s\n" "networking"          "mtr, bandwhich, nmap"
-    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, Kiro, Ghostty, zellij, Raycast, aider, llm, repomix"
+    printf "  %-25s %s\n" "dx"                  "fzf, starship, atuin, Kiro, VS Code, Ghostty, zellij, Raycast, aider, llm, repomix"
     printf "  %-25s %s\n" "ux"                  "Lighthouse"
-    printf "  %-25s %s\n" "docs"                "d2, Mermaid CLI"
-    printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins, mas, dockutil, terminal-notifier"
-    printf "  %-25s %s\n" "mac-productivity"    "Notion, Skim, Transmit"
-    printf "  %-25s %s\n" "mac-communication"   "Slack, Telegram"
-    printf "  %-25s %s\n" "mac-browsers"        "Firefox, Brave, Carbonyl, w3m, monolith"
-    printf "  %-25s %s\n" "mac-media"           "mpv, oxipng, jpegoptim, 7zip, LibreOffice, cmus"
+    printf "  %-25s %s\n" "docs"                "d2, Mermaid CLI, draw.io"
+    printf "  %-25s %s\n" "mac-system"          "Pearcleaner, Quick Look plugins, dockutil, terminal-notifier"
+    printf "  %-25s %s\n" "mac-productivity"    "Notion, Skim, Cyberduck"
+    printf "  %-25s %s\n" "mac-browsers"        "Carbonyl, w3m, monolith"
+    printf "  %-25s %s\n" "mac-media"           "mpv, oxipng, jpegoptim, 7zip, cmus"
     printf "  %-25s %s\n" "mac-cloud"           "Google Drive, rclone, borg"
     printf "  %-25s %s\n" "mac-focus"           "newsboat"
     printf "  %-25s %s\n" "mac-bloat"           "Remove pre-installed Apple apps (GarageBand)"
@@ -807,7 +804,6 @@ if [[ "$CLEANUP" == "true" ]]; then
         "cask:warp:Warp terminal:Ghostty:Warp"
         "cask:iterm2:iTerm2:Ghostty:iTerm"
         "cask:cursor:Cursor (AI editor):Kiro + Claude Code:Cursor"
-        "cask:visual-studio-code:VS Code:Kiro (VS Code fork with built-in Claude agent):Visual Studio Code"
         "cask:cleanshot:CleanShot X:removed"
         "cask:soulver:Soulver 3:removed:Soulver 3"
         "cask:numi:Numi:removed"
@@ -817,7 +813,10 @@ if [[ "$CLEANUP" == "true" ]]; then
         "cask:wireshark:Wireshark:removed"
         "cask:topnotch:TopNotch:removed"
         "cask:syncthing:Syncthing:removed"
-        "cask:arc:Arc:Brave"
+        "cask:arc:Arc:Google Chrome"
+        "cask:firefox:Firefox:removed"
+        "cask:brave-browser:Brave Browser:removed:Brave Browser"
+        "cask:postman:Postman:Bruno"
         "cask:daisydisk:DaisyDisk:dust + duf (CLI)"
         "cask:proxyman:Proxyman:mitmproxy"
         "cask:appcleaner:AppCleaner:Pearcleaner"
@@ -845,7 +844,7 @@ if [[ "$CLEANUP" == "true" ]]; then
         "formula:git-secrets:git-secrets:gitleaks + detect-secrets"
         "formula:trufflehog:trufflehog:gitleaks + detect-secrets"
         "cask:the-unarchiver:The Unarchiver:p7zip (CLI)"
-        "cask:cyberduck:Cyberduck:Transmit"
+        "cask:transmit:Transmit:Cyberduck:Transmit"
         "cask:colima:colima:OrbStack"
         "cask:blockblock:BlockBlock:removed"
         "cask:oversight:OverSight:removed"
@@ -855,16 +854,21 @@ if [[ "$CLEANUP" == "true" ]]; then
         "mas:937984704:Amphetamine:removed"
         "cask:stats:Stats:removed"
         "cask:rectangle:Rectangle:removed"
-        "cask:shottr:Shottr:removed"
+        "cask:snagit:Snagit:Shottr:Snagit"
         "cask:signal:Signal:removed"
         "formula:gifski:gifski:removed"
         "mas:6475002485:Reeder:newsboat"
         "formula:mas:mas:removed"
-        "cask:dbeaver-community:DBeaver Community:pgcli/mycli/sq (CLI):DBeaver"
+        "cask:tableplus:TablePlus:DBeaver:TablePlus"
         "cask:iina:IINA:mpv (CLI)"
         "cask:imageoptim:ImageOptim:oxipng + jpegoptim (CLI)"
         "cask:keka:Keka:p7zip (CLI)"
         "formula:entr:entr:watchexec"
+        "cask:zed:Zed:Kiro + VS Code:Zed"
+        "cask:slack:Slack:removed"
+        "cask:telegram:Telegram:removed"
+        "cask:notion-mail:Notion Mail:removed (retired by Notion):Notion Mail"
+        "cask:libreoffice:LibreOffice:Google Workspace:LibreOffice"
     )
 
     CLEANUP_COUNT=0
@@ -1572,7 +1576,7 @@ else
 fi
 brew_install "neilotoole/sq/sq" "sq (jq for databases — query SQLite, Postgres, CSV from one tool)"
 brew_install "dbmate" "dbmate (lightweight DB migrations)"
-brew_cask_install "tableplus" "TablePlus (native DB GUI — daily driver)"
+brew_cask_install "dbeaver-community" "DBeaver Community (free, open-source universal DB GUI)"
 
 fi  # database
 
@@ -1591,7 +1595,7 @@ fi  # containers
 if should_run "api"; then
 banner "API Development"
 
-brew_cask_install "postman" "Postman (industry-standard API client)"
+brew_cask_install "bruno" "Bruno (local-first, git-friendly API client)"
 brew_install "grpcurl" "grpcurl (curl for gRPC)"
 
 fi  # api
@@ -1637,6 +1641,7 @@ if [[ -f "$KIRO_CLI" ]] && ! installed kiro; then
     sudo ln -sf "$KIRO_CLI" "$KIRO_LINK_DIR/kiro" 2>/dev/null || true
     hash -r 2>/dev/null || true
 fi
+brew_cask_install "visual-studio-code" "Visual Studio Code (same extensions as Kiro)"
 brew_cask_install "ghostty" "Ghostty (fast GPU-accelerated terminal)"
 brew_install "zellij" "zellij (modern terminal multiplexer — discoverable UI, layouts)"
 
@@ -1727,6 +1732,8 @@ else
     progress  # keep progress bar accurate when npm unavailable
 fi
 
+brew_cask_install "drawio" "draw.io (open-source desktop diagram editor — architecture & system diagrams)"
+
 fi  # docs
 
 # =============================================================================
@@ -1740,8 +1747,7 @@ brew_cask_install "mullvadvpn" "Mullvad VPN (privacy-focused, no account email r
 # Utilities
 brew_cask_install "pearcleaner" "Pearcleaner (open-source deep app uninstaller)"
 
-# macOS scripting helpers — used by this script (Dock, notifications, MAS apps)
-brew_install "mas" "mas (Mac App Store CLI — install/update MAS apps from a script)"
+# macOS scripting helpers — used by this script (Dock pins, notifications)
 brew_install "dockutil" "dockutil (manage Dock pins programmatically)"
 brew_install "terminal-notifier" "terminal-notifier (send macOS notifications from shell scripts)"
 
@@ -1759,33 +1765,21 @@ banner "Mac Apps — Productivity"
 brew_cask_install "claude" "Claude (AI assistant)"
 brew_cask_install "notion" "Notion (docs, wikis, project tracking)"
 brew_cask_install "notion-calendar" "Notion Calendar"
-brew_cask_install "notion-mail" "Notion Mail"
-brew_cask_install "snagit" "Snagit (screenshots, scrolling capture, annotations, video)"
+brew_cask_install "shottr" "Shottr (fast native screenshots — scrolling capture, OCR, annotations)"
 
 # PDF & documents
 brew_cask_install "skim" "Skim (lightweight PDF reader with annotations — faster than Preview)"
 
 # File transfer
-brew_cask_install "transmit" "Transmit (fast SFTP/S3 client, dual-pane)"
+brew_cask_install "cyberduck" "Cyberduck (free, open-source SFTP/S3/cloud transfer)"
 
 fi  # mac-productivity
-
-# =============================================================================
-if should_run "mac-communication"; then
-banner "Mac Apps — Communication"
-
-brew_cask_install "slack" "Slack"
-brew_cask_install "telegram" "Telegram"
-
-fi  # mac-communication
 
 # =============================================================================
 if should_run "mac-browsers"; then
 banner "Mac Apps — Browsers"
 
 brew_cask_install "google-chrome" "Google Chrome"
-brew_cask_install "firefox" "Firefox"
-brew_cask_install "brave-browser" "Brave Browser (privacy-focused Chromium)"
 
 npm_global_install "carbonyl" "Carbonyl (Chromium-based browser for the terminal)"
 brew_install "w3m" "w3m (text-based terminal browser and pager)"
@@ -1802,7 +1796,6 @@ brew_install "oxipng" "oxipng (lossless PNG compression)"
 brew_install "jpegoptim" "jpegoptim (lossless JPEG compression)"
 brew_install "p7zip" "7zip (archive tool — zip, 7z, rar, tar)"
 brew_install "cmus" "cmus (ncurses terminal music player)"
-brew_cask_install "libreoffice" "LibreOffice (free office suite)"
 
 fi  # mac-media
 
@@ -2023,11 +2016,13 @@ read_only = " 󰌾"
 read_only_style = "fg:red"
 
 [directory.substitutions]
-"Documents" = "󰈙 "
+"Inbox" = "📥 "
+"Docs" = "󰈙 "
 "Downloads" = " "
 "Code" = " "
 "Creative" = "🎨"
 "Media" = "🎵"
+"Archive" = "📦 "
 
 # -- Git branch ---------------------------------------------------------------
 [git_branch]
@@ -2722,63 +2717,76 @@ fi
 mark_done "config:kiro-settings"
 fi
 
-# ---- Kiro essential extensions (resolved from OpenVSX) ----
-# Note: Kiro is a VS Code fork that uses OpenVSX, not the Microsoft Marketplace.
-# Closed-source extensions like github.copilot and ms-vscode.* are unavailable —
-# Kiro ships its own AI agent (Claude Sonnet), so Copilot is redundant anyway.
-if installed kiro; then
-    info "Installing Kiro extensions (from OpenVSX)..."
-    KIRO_EXTENSIONS=(
-        # Theme
-        "dracula-theme.theme-dracula"
-        # Formatting & linting
-        "esbenp.prettier-vscode"
-        "dbaeumer.vscode-eslint"
-        "charliermarsh.ruff"
-        # Language support
-        "bradlc.vscode-tailwindcss"
-        "ms-python.python"
-        "golang.go"
-        "rust-lang.rust-analyzer"
-        "astro-build.astro-vscode"
-        "svelte.svelte-vscode"
-        # Editor enhancements
-        "formulahendry.auto-rename-tag"
-        "christian-kohler.path-intellisense"
-        "usernamehw.errorlens"
-        "aaron-bond.better-comments"
-        "streetsidesoftware.code-spell-checker"
-        "christian-kohler.npm-intellisense"
-        "naumovs.color-highlight"
-        "mechatroner.rainbow-csv"
-        "editorconfig.editorconfig"
-        # Git
-        "eamodio.gitlens"
-        "mhutchie.git-graph"
-        # Productivity
-        "gruntfuggly.todo-tree"
-        "wix.vscode-import-cost"
-        "ms-azuretools.vscode-docker"
-        "mikestead.dotenv"
-        "yzhang.markdown-all-in-one"
-        "davidanson.vscode-markdownlint"
-        "redhat.vscode-yaml"
-        "tamasfe.even-better-toml"
-        "hashicorp.terraform"
-        # AWS development
-        "amazonwebservices.aws-toolkit-vscode"
-        "kddejong.vscode-cfn-lint"
-    )
-    for ext in "${KIRO_EXTENSIONS[@]}"; do
-        if kiro --list-extensions 2>/dev/null | grep -qi "$ext"; then
-            warn "Kiro extension $ext already installed"
+# ---- Editor extensions (shared by Kiro and VS Code) ----
+# Kiro is a VS Code fork, so both editors use identical extension IDs — Kiro
+# resolves them from OpenVSX, VS Code from the Microsoft Marketplace.
+# Closed-source extensions like github.copilot and ms-vscode.* are unavailable
+# on OpenVSX; Kiro ships its own AI agent (Claude Sonnet), so Copilot is redundant.
+EDITOR_EXTENSIONS=(
+    # Theme
+    "dracula-theme.theme-dracula"
+    # Formatting & linting
+    "esbenp.prettier-vscode"
+    "dbaeumer.vscode-eslint"
+    "charliermarsh.ruff"
+    # Language support
+    "bradlc.vscode-tailwindcss"
+    "ms-python.python"
+    "golang.go"
+    "rust-lang.rust-analyzer"
+    "astro-build.astro-vscode"
+    "svelte.svelte-vscode"
+    # Editor enhancements
+    "formulahendry.auto-rename-tag"
+    "christian-kohler.path-intellisense"
+    "usernamehw.errorlens"
+    "aaron-bond.better-comments"
+    "streetsidesoftware.code-spell-checker"
+    "christian-kohler.npm-intellisense"
+    "naumovs.color-highlight"
+    "mechatroner.rainbow-csv"
+    "editorconfig.editorconfig"
+    # Git
+    "eamodio.gitlens"
+    "mhutchie.git-graph"
+    # Productivity
+    "gruntfuggly.todo-tree"
+    "wix.vscode-import-cost"
+    "ms-azuretools.vscode-docker"
+    "mikestead.dotenv"
+    "yzhang.markdown-all-in-one"
+    "davidanson.vscode-markdownlint"
+    "redhat.vscode-yaml"
+    "tamasfe.even-better-toml"
+    "hashicorp.terraform"
+    # AWS development
+    "amazonwebservices.aws-toolkit-vscode"
+    "kddejong.vscode-cfn-lint"
+)
+
+# install_editor_extensions <cli> <source-label>
+# Installs EDITOR_EXTENSIONS into an editor via its CLI, skipping any already present.
+install_editor_extensions() {
+    local editor_cli="$1" source="$2" ext
+    info "Installing extensions for $editor_cli (from $source)..."
+    for ext in "${EDITOR_EXTENSIONS[@]}"; do
+        if "$editor_cli" --list-extensions 2>/dev/null | grep -qi "$ext"; then
+            warn "$editor_cli extension $ext already installed"
         else
-            if ! kiro --install-extension "$ext" >> "$LOG_FILE" 2>&1; then
-                warn "Failed to install Kiro extension: $ext (may not be on OpenVSX)"
+            if ! "$editor_cli" --install-extension "$ext" >> "$LOG_FILE" 2>&1; then
+                warn "Failed to install $editor_cli extension: $ext (may not be on $source)"
             fi
         fi
     done
-    success "Kiro extensions installed"
+    success "$editor_cli extensions installed"
+}
+
+if installed kiro; then
+    install_editor_extensions kiro "OpenVSX"
+fi
+
+if installed code; then
+    install_editor_extensions code "the Microsoft Marketplace"
 fi
 
 # ---- Kiro MCP servers (global config) ----
@@ -5630,7 +5638,14 @@ fi
 if should_run "filesystem"; then
 info "Setting up filesystem structure..."
 
+# ADD-friendly layout: few top-level roots, shallow nesting, no overlapping
+# categories, and an ~/Inbox dump zone so nothing needs to be filed in the moment.
+# ~/Code is kept as-is because aliases, per-directory git identity, mise/direnv
+# trust, and the MCP filesystem scope all depend on it.
 DIRS=(
+    # -- Inbox (dump zone — drop anything here, sort later or never) -----------
+    "$HOME/Inbox"
+
     # -- Development ----------------------------------------------------------
     "$HOME/Code/work"
     "$HOME/Code/work/scratch"
@@ -5647,50 +5662,30 @@ DIRS=(
     # -- Screenshots ----------------------------------------------------------
     "$HOME/Screenshots"
 
-    # -- Documents (organized by life area) -----------------------------------
-    "$HOME/Documents/finance/taxes"
-    "$HOME/Documents/finance/invoices"
-    "$HOME/Documents/finance/statements"
-    "$HOME/Documents/health"
-    "$HOME/Documents/legal"
-    "$HOME/Documents/travel"
-    "$HOME/Documents/insurance"
-    "$HOME/Documents/contracts"
-    "$HOME/Documents/receipts"
-    "$HOME/Documents/design"
+    # -- Docs (life admin — a few flat, non-overlapping buckets) --------------
+    "$HOME/Docs/finance"    # statements, taxes, invoices
+    "$HOME/Docs/health"
+    "$HOME/Docs/admin"      # legal, insurance, contracts
+    "$HOME/Docs/receipts"
+    "$HOME/Docs/travel"
 
-    # -- Reference (quick-access knowledge) -----------------------------------
-    "$HOME/Reference/manuals"
-    "$HOME/Reference/cheatsheets"
-    "$HOME/Reference/bookmarks-export"
-
-    # -- Creative -------------------------------------------------------------
-    "$HOME/Creative/design"
+    # -- Creative (flat) ------------------------------------------------------
     "$HOME/Creative/writing"
-    "$HOME/Creative/video-editing"
-    "$HOME/Creative/assets/icons"
-    "$HOME/Creative/assets/fonts"
-    "$HOME/Creative/assets/stock-photos"
-    "$HOME/Creative/assets/templates"
+    "$HOME/Creative/design"
+    "$HOME/Creative/video"
 
     # -- Media ----------------------------------------------------------------
     "$HOME/Media/photos"
     "$HOME/Media/videos"
     "$HOME/Media/music"
-    "$HOME/Media/wallpapers"
 
-    # -- Projects (non-code personal projects) --------------------------------
-    "$HOME/Projects/side-hustles"
-    "$HOME/Projects/home"
-
-    # -- Archive (cold storage for old stuff) ---------------------------------
-    "$HOME/Archive/old-projects"
-    "$HOME/Archive/old-docs"
+    # -- Archive (one bucket for old/done stuff) ------------------------------
+    "$HOME/Archive"
 )
 for dir in "${DIRS[@]}"; do
     mkdir -p "$dir"
 done
-success "Directory structure created (~/Code, ~/Scripts, ~/Documents, ~/Reference, ~/Creative, ~/Media, ~/Projects, ~/Archive)"
+success "Directory structure created (~/Inbox, ~/Code, ~/Scripts, ~/Docs, ~/Creative, ~/Media, ~/Archive)"
 
 # ---- Helper Scripts ----
 info "Creating helper scripts in ~/Scripts/bin..."
@@ -6363,18 +6358,18 @@ SIDEBAR_SWIFT
         "$SIDEBAR_TOOL" remove "$HOME/Music" 2>/dev/null || true
         "$SIDEBAR_TOOL" remove "$HOME/Pictures" 2>/dev/null || true
 
-        # Add our organized folders to sidebar
+        # Add our organized folders to sidebar.
+        # Inbox and Downloads (the two dump zones) go first for zero-friction access.
         SIDEBAR_FOLDERS=(
+            "$HOME/Inbox"
+            "$HOME/Downloads"
             "$HOME/Code"
-            "$HOME/Screenshots"
-            "$HOME/Scripts"
-            "$HOME/Documents"
-            "$HOME/Reference"
+            "$HOME/Docs"
             "$HOME/Creative"
             "$HOME/Media"
-            "$HOME/Projects"
             "$HOME/Archive"
-            "$HOME/Downloads"
+            "$HOME/Screenshots"
+            "$HOME/Scripts"
         )
 
         sidebar_added=0
@@ -6711,11 +6706,11 @@ else
       "Bash(gum *)",
       "Bash(uvx *)",
       "Bash(kiro *)",
+      "Bash(code *)",
       "Bash(aider *)",
       "Bash(llm *)",
       "Bash(repomix *)",
       "Bash(chezmoi *)",
-      "Bash(mas *)",
       "Bash(dockutil *)",
       "Bash(terminal-notifier *)",
       "Bash(ouch *)",
@@ -6828,7 +6823,7 @@ else
 
 ## Environment
 - Shell: zsh with starship prompt, atuin history, fzf fuzzy finder, zsh-autosuggestions, zsh-syntax-highlighting
-- Editor: Kiro (Dracula theme, JetBrains Mono — VS Code fork with built-in Claude agent)
+- Editors: Kiro (primary — VS Code fork with built-in Claude agent) and VS Code (same extension set); both Dracula theme, JetBrains Mono. CLIs available: `kiro`, `code`
 - Terminal: Ghostty (Dracula theme)
 - Package managers: pnpm (preferred), npm, bun
 - Python: uv for packages (not pip), ruff for linting (not flake8/black)
@@ -6839,10 +6834,23 @@ else
 - Shell note: `bat` is aliased to `cat`; use `/bin/cat` only inside heredoc subshells where bat breaks syntax
 - Dotfiles: chezmoi
 - Launcher: Raycast
-- API client: Postman
-- Database GUI: TablePlus
+- API client: Bruno (local-first, git-friendly — collections as `.bru` files)
+- Database: DBeaver (GUI) + CLIs pgcli, mycli, lazysql, harlequin, usql, sq; migrations via dbmate
+- Diagrams: draw.io (GUI, architecture/system diagrams) + d2 / Mermaid (code-based)
+- Screenshots: Shottr (saved to ~/Screenshots)
+- File transfer: Cyberduck (GUI) + rclone (CLI)
 - Proxy/debugger: mitmproxy
 - Tunneling: ngrok
+- Docs / PM: Notion (+ Notion Calendar)
+- Cloud storage: Google Drive desktop (primary sync) + rclone; borg for versioned backups
+- Browser: Google Chrome (primary); Carbonyl / w3m in the terminal
+- Password manager: Apple Passwords (iCloud Keychain) — no third-party manager installed
+
+## Working Context
+- Independent **fractional CIO/CTO and consultant**; company is **VixenTec LLC**.
+- All company work runs on **Google Workspace** (Gmail, Docs/Sheets/Slides, Drive, Meet, Chat, Vids). Produce documents/deliverables in Google Workspace, not a local office suite (no LibreOffice/MS Office installed). Use **Google Meet** for calls (no Zoom); **Google Chat** for messaging (no Slack).
+- Tool philosophy: prefer **open-source, CLI-first, privacy-preserving, and minimal** options; declutter aggressively. When recommending tools, lead with one option that fits these and flag any that don't.
+- **ADD-friendly home layout** (low-decision, shallow): `~/Inbox` (dump zone — drop anything, sort later), `~/Code` (work/personal/oss/learning), `~/Docs` (finance, health, admin, receipts, travel), `~/Creative`, `~/Media`, `~/Archive`, `~/Screenshots`, `~/Scripts`. When in doubt where a file goes, suggest `~/Inbox` rather than a deep path.
 
 ## Available CLI Tools (use these instead of manual approaches)
 - **Search**: `rg` (ripgrep) for content, `fd` for files, `fzf` for interactive


### PR DESCRIPTION
Closes #38

## Summary
Curates the macOS setup script for a solo **fractional CIO/CTO + consulting** workflow (VixenTec LLC runs on Google Workspace), introduces an **ADD-friendly** home-folder layout, and updates the generated Claude config to reflect the current toolset. Docs kept in sync throughout.

## Changes
**Apps — added**
- **VS Code** — installed alongside Kiro, sharing one `EDITOR_EXTENSIONS` list (Kiro→OpenVSX, VS Code→Marketplace) via a new `install_editor_extensions` helper
- **Bruno** (replaces Postman), **DBeaver** (replaces TablePlus), **Cyberduck** (replaces Transmit), **Shottr** (replaces Snagit), **draw.io**

**Apps — removed** (each added to the `--cleanup` `DEPRECATED_TOOLS` list)
- Brave, Firefox, Slack, Telegram, Notion Mail, Zed, Postman, Snagit, Transmit, TablePlus, LibreOffice
- **mas** dropped entirely — no Mac App Store installs remained; resolves the install-vs-cleanup contradiction

**Filesystem — ADD-friendly restructure**
- New `~/Inbox` dump zone; `~/Docs` flattened to a few buckets (finance/health/admin/receipts/travel); collapsed Reference/Projects/Creative-assets; one `~/Archive` bucket
- Inbox + Downloads pinned first in the Finder sidebar; starship folder icons updated
- `~/Code` intentionally untouched (aliases, git identity, mise/direnv trust, MCP scope depend on it)

**Categories**
- Removed the now-empty `mac-communication` category (Slack + Telegram both gone)

**Claude config**
- Generated global `CLAUDE.md`: expanded Environment + new Working Context section (Google Workspace, tool philosophy, ADD layout)
- settings.json: grant `Bash(code *)`, drop `Bash(mas *)`

**Docs**
- README.md and docs/GUIDE.md synced (app tables, filesystem tree, setup sections)

## Test Plan
- [x] `bash -n scripts/setup-dev-tools-mac.sh` — passes
- [x] `shellcheck -x -S warning scripts/setup-dev-tools-mac.sh` (CI's exact invocation) — clean
- [x] `gitleaks detect` — no leaks
- [x] Generated `settings.json` heredoc validated as JSON after edits
- [ ] Full run on a fresh macOS install (deferred — will validate on the upcoming clean reinstall)

Note: the `--cleanup` subsystem is intentionally kept (opt-in, inert on fresh installs; it's the safety net that retires these apps on any non-wiped re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)